### PR TITLE
Split scheduled endpoints into consent controllers

### DIFF
--- a/IYSIntegration.API/Controllers/ConsentErrorReportController.cs
+++ b/IYSIntegration.API/Controllers/ConsentErrorReportController.cs
@@ -1,0 +1,33 @@
+using IYSIntegration.Common.Worker.Services;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.API.Controllers
+{
+    [ApiController]
+    [Route("api/consent-error-report")]
+    public class ConsentErrorReportController : ControllerBase
+    {
+        private readonly SendConsentErrorService _sendConsentErrorService;
+
+        public ConsentErrorReportController(SendConsentErrorService sendConsentErrorService)
+        {
+            _sendConsentErrorService = sendConsentErrorService;
+        }
+
+        [HttpPost("send-consent-error/excel")]
+        public async Task<IActionResult> RunSendConsentErrorExcel([FromQuery] DateTime? date)
+        {
+            var result = await _sendConsentErrorService.GetReportExcelAsync(date ?? DateTime.Today);
+            return Ok(result);
+        }
+
+        [HttpPost("send-consent-error/json")]
+        public async Task<IActionResult> RunSendConsentErrorJson([FromQuery] DateTime? date)
+        {
+            var result = await _sendConsentErrorService.GetReportJsonAsync(date ?? DateTime.Today);
+            return Ok(result);
+        }
+    }
+}

--- a/IYSIntegration.API/Controllers/ConsentScheduleController.cs
+++ b/IYSIntegration.API/Controllers/ConsentScheduleController.cs
@@ -1,32 +1,28 @@
 using IYSIntegration.Common.Worker.Services;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using System.Threading.Tasks;
 
 namespace IYSIntegration.API.Controllers
 {
     [ApiController]
-    [Route("api/[controller]")]
-    public class ScheduledController : ControllerBase
+    [Route("api/consent-schedule")]
+    public class ConsentScheduleController : ControllerBase
     {
         private readonly SingleConsentService _singleConsentService;
         private readonly MultipleConsentService _multipleConsentService;
         private readonly PullConsentService _pullConsentService;
         private readonly SfConsentService _sfConsentService;
-        private readonly SendConsentErrorService _sendConsentErrorService;
 
-        public ScheduledController(
+        public ConsentScheduleController(
             SingleConsentService singleConsentService,
             MultipleConsentService multipleConsentService,
             PullConsentService pullConsentService,
-            SfConsentService sfConsentService,
-            SendConsentErrorService sendConsentErrorService)
+            SfConsentService sfConsentService)
         {
             _singleConsentService = singleConsentService;
             _multipleConsentService = multipleConsentService;
             _pullConsentService = pullConsentService;
             _sfConsentService = sfConsentService;
-            _sendConsentErrorService = sendConsentErrorService;
         }
 
         [HttpPost("single-consent")]
@@ -54,20 +50,6 @@ namespace IYSIntegration.API.Controllers
         public async Task<IActionResult> RunSfConsent()
         {
             var result = await _sfConsentService.ProcessAsync();
-            return Ok(result);
-        }
-
-        [HttpPost("send-consent-error/excel")]
-        public async Task<IActionResult> RunSendConsentErrorExcel([FromQuery] DateTime? date)
-        {
-            var result = await _sendConsentErrorService.GetReportExcelAsync(date ?? DateTime.Today);
-            return Ok(result);
-        }
-
-        [HttpPost("send-consent-error/json")]
-        public async Task<IActionResult> RunSendConsentErrorJson([FromQuery] DateTime? date)
-        {
-            var result = await _sendConsentErrorService.GetReportJsonAsync(date ?? DateTime.Today);
             return Ok(result);
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # IYSRestruct
 
-## Scheduled Controller
+## Consent Schedule ve Error Report Controller'ları
 
-`IYSIntegration.WorkerService` fonksiyonları API içine taşınmıştır. Aşağıdaki uç noktalar `ScheduledController` altında yer alır:
+`IYSIntegration.WorkerService` fonksiyonları API içine taşınmıştır. Konsent işlemleri artık `ConsentScheduleController` ve `ConsentErrorReportController` altında gruplanmıştır:
 
-- `POST /api/scheduled/single-consent`
-- `POST /api/scheduled/multiple-consent`
-- `POST /api/scheduled/pull-consent`
-- `POST /api/scheduled/sf-consent`
-- `POST /api/scheduled/send-consent-error/excel`
-- `POST /api/scheduled/send-consent-error/json`
+### ConsentScheduleController uç noktaları
+
+- `POST /api/consent-schedule/single-consent`
+- `POST /api/consent-schedule/multiple-consent`
+- `POST /api/consent-schedule/pull-consent`
+- `POST /api/consent-schedule/sf-consent`
+
+### ConsentErrorReportController uç noktaları
+
+- `POST /api/consent-error-report/send-consent-error/excel`
+- `POST /api/consent-error-report/send-consent-error/json`
 
 `send-consent-error` uç noktaları `date` sorgu parametresi alır ve istenen tarih için hatalı kayıtları döndürür.
 


### PR DESCRIPTION
## Summary
- replace `ScheduledController` with `ConsentScheduleController`
- add `ConsentErrorReportController` for consent error reports
- document new endpoints in README

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b443bf58208322976a5f9104c54da3