### PR TITLE
Use company code for pull consent and add SF forwarding

### DIFF
--- a/IYSIntegration.API/Controllers/CommonController.cs
+++ b/IYSIntegration.API/Controllers/CommonController.cs
@@ -199,18 +199,11 @@ namespace IYSIntegration.API.Controllers
         }
 
 
-        [Route("pullConsent")]
-        [HttpPost]
-        public async Task<ResponseBase<PullConsentResult>> PullConsent(PullConsentRequest request)
+        [Route("pullConsent/{companyCode}")]
+        [HttpGet]
+        public async Task<ResponseBase<PullConsentResult>> PullConsent(string companyCode)
         {
-            if (request.IysCode == 0)
-            {
-                var consentParams = GetIysCode(request.CompanyCode);
-                request.IysCode = consentParams.IysCode;
-                request.BrandCode = consentParams.BrandCode;
-            }
-
-            return await _consentManager.PullConsent(request);
+            return await _consentManager.PullConsent(companyCode);
         }
 
         [Route("sfaddconsent")]

--- a/IYSIntegration.API/Controllers/ConsentApiPullController.cs
+++ b/IYSIntegration.API/Controllers/ConsentApiPullController.cs
@@ -1,26 +1,34 @@
 using IYSIntegration.Application.Interface;
 using IYSIntegration.Common.Request.Consent;
+using IYSIntegration.Common.Response.Consent;
 using Microsoft.AspNetCore.Mvc;
 
 namespace IYSIntegration.API.Controllers
 {
     [ApiController]
-    [Route("api/consent/{iysCode}/brands/{brandCode}")]
+    [Route("api/consent")]
     public class ConsentApiPullController : ControllerBase
     {
         private readonly IConsentService _consentManager;
-        public ConsentApiPullController(IConsentService consentManager)
+        private readonly ISfConsentService _sfConsentManager;
+
+        public ConsentApiPullController(IConsentService consentManager, ISfConsentService sfConsentManager)
         {
             _consentManager = consentManager;
+            _sfConsentManager = sfConsentManager;
         }
 
-        [Route("consents/changes")]
-        [HttpGet]
-        public async Task<IActionResult> PullConsent(int iysCode, int brandCode, string after, int limit, string source)
+        [HttpGet("{companyCode}/consents/changes")]
+        public async Task<IActionResult> PullConsent(string companyCode)
         {
-            var request = new PullConsentRequest { IysCode = iysCode, BrandCode = brandCode, After = after, Limit = limit, Source = source };
-            var result = await _consentManager.PullConsent(request);
+            var result = await _consentManager.PullConsent(companyCode);
             return Ok(result);
+        }
+
+        [HttpPost("sfaddconsent")]
+        public async Task<SfConsentAddResponse> SalesforceAddConsent(SfConsentAddRequest request)
+        {
+            return await _sfConsentManager.AddConsent(request);
         }
     }
 }

--- a/IYSIntegration.API/appsettings.Development.json
+++ b/IYSIntegration.API/appsettings.Development.json
@@ -5,5 +5,7 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-  }
+  },
+  "PullConsentBatchSize": 100,
+  "PullConsentAfter": ""
 }

--- a/IYSIntegration.API/appsettings.Production.json
+++ b/IYSIntegration.API/appsettings.Production.json
@@ -13,6 +13,8 @@
   "RefreshTokenExpiresIn": "14400",
   "BaseUrl": "https://api.iys.org.tr",
   "LogPath": "D:\\Logs\\IYS\\API",
+  "PullConsentBatchSize": 100,
+  "PullConsentAfter": "",
   "BOI": {
     "IysCode": "679648",
     "BrandCode": "679648"

--- a/IYSIntegration.API/appsettings.json
+++ b/IYSIntegration.API/appsettings.json
@@ -20,6 +20,7 @@
   "SingleConsentProcessRowCount": 80,
   "RunAsSingle": true,
   "PullConsentBatchSize": 100,
+  "PullConsentAfter": "",
   "SfConsentProcessRowCount": 100,
   "IYSErrorMail": {
     "Schedule": "0 15 8 * * *",

--- a/IYSIntegration.Application/Interface/IConsentService.cs
+++ b/IYSIntegration.Application/Interface/IConsentService.cs
@@ -10,7 +10,7 @@ namespace IYSIntegration.Application.Interface
         Task<ResponseBase<QueryConsentResult>> QueryConsent(QueryConsentRequest request);
         Task<ResponseBase<MultipleConsentResult>> AddMultipleConsent(MultipleConsentRequest request);
         Task<ResponseBase<List<QueryMultipleConsentResult>>> QueryMultipleConsent(QueryMultipleConsentRequest request);
-        Task<ResponseBase<PullConsentResult>> PullConsent(PullConsentRequest request);
+        Task<ResponseBase<PullConsentResult>> PullConsent(string companyCode);
     }
 }
 


### PR DESCRIPTION
## Summary
- fetch IYS and brand codes inside consent service using company code
- load pull consent limit/after values from appsettings and default source to IYS
- expose Salesforce consent endpoint alongside pull consent API

## Testing
- `dotnet build IYSIntegration.sln`
- `dotnet test IYSIntegration.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b44f7a61b8832293fa7a538b321f2b