### PR TITLE
Use company code for pull consent and add SF forwarding

### DIFF
--- a/IYSIntegration.API/Controllers/CommonController.cs
+++ b/IYSIntegration.API/Controllers/CommonController.cs
@@ -199,18 +199,11 @@ namespace IYSIntegration.API.Controllers
         }
 
 
-        [Route("pullConsent")]
-        [HttpPost]
-        public async Task<ResponseBase<PullConsentResult>> PullConsent(PullConsentRequest request)
+        [Route("pullConsent/{companyCode}")]
+        [HttpGet]
+        public async Task<ResponseBase<PullConsentResult>> PullConsent(string companyCode)
         {
-            if (request.IysCode == 0)
-            {
-                var consentParams = GetIysCode(request.CompanyCode);
-                request.IysCode = consentParams.IysCode;
-                request.BrandCode = consentParams.BrandCode;
-            }
-
-            return await _consentManager.PullConsent(request);
+            return await _consentManager.PullConsent(companyCode);
         }
 
         [Route("sfaddconsent")]

--- a/IYSIntegration.API/Controllers/ConsentScheduleController.cs
+++ b/IYSIntegration.API/Controllers/ConsentScheduleController.cs
@@ -10,19 +10,13 @@ namespace IYSIntegration.API.Controllers
     {
         private readonly SingleConsentService _singleConsentService;
         private readonly MultipleConsentService _multipleConsentService;
-        private readonly PullConsentService _pullConsentService;
-        private readonly SfConsentService _sfConsentService;
 
         public ConsentScheduleController(
             SingleConsentService singleConsentService,
-            MultipleConsentService multipleConsentService,
-            PullConsentService pullConsentService,
-            SfConsentService sfConsentService)
+            MultipleConsentService multipleConsentService)
         {
             _singleConsentService = singleConsentService;
             _multipleConsentService = multipleConsentService;
-            _pullConsentService = pullConsentService;
-            _sfConsentService = sfConsentService;
         }
 
         [HttpPost("single-consent")]
@@ -39,18 +33,5 @@ namespace IYSIntegration.API.Controllers
             return Ok(result);
         }
 
-        [HttpPost("pull-consent")]
-        public async Task<IActionResult> RunPullConsent()
-        {
-            var result = await _pullConsentService.ProcessAsync();
-            return Ok(result);
-        }
-
-        [HttpPost("sf-consent")]
-        public async Task<IActionResult> RunSfConsent()
-        {
-            var result = await _sfConsentService.ProcessAsync();
-            return Ok(result);
-        }
     }
 }

--- a/IYSIntegration.API/appsettings.Development.json
+++ b/IYSIntegration.API/appsettings.Development.json
@@ -5,5 +5,7 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-  }
+  },
+  "PullConsentBatchSize": 100,
+  "PullConsentAfter": ""
 }

--- a/IYSIntegration.API/appsettings.Production.json
+++ b/IYSIntegration.API/appsettings.Production.json
@@ -13,6 +13,8 @@
   "RefreshTokenExpiresIn": "14400",
   "BaseUrl": "https://api.iys.org.tr",
   "LogPath": "D:\\Logs\\IYS\\API",
+  "PullConsentBatchSize": 100,
+  "PullConsentAfter": "",
   "BOI": {
     "IysCode": "679648",
     "BrandCode": "679648"

--- a/IYSIntegration.API/appsettings.json
+++ b/IYSIntegration.API/appsettings.json
@@ -20,6 +20,7 @@
   "SingleConsentProcessRowCount": 80,
   "RunAsSingle": true,
   "PullConsentBatchSize": 100,
+  "PullConsentAfter": "",
   "SfConsentProcessRowCount": 100,
   "IYSErrorMail": {
     "Schedule": "0 15 8 * * *",

--- a/IYSIntegration.Application/Interface/IConsentService.cs
+++ b/IYSIntegration.Application/Interface/IConsentService.cs
@@ -10,7 +10,7 @@ namespace IYSIntegration.Application.Interface
         Task<ResponseBase<QueryConsentResult>> QueryConsent(QueryConsentRequest request);
         Task<ResponseBase<MultipleConsentResult>> AddMultipleConsent(MultipleConsentRequest request);
         Task<ResponseBase<List<QueryMultipleConsentResult>>> QueryMultipleConsent(QueryMultipleConsentRequest request);
-        Task<ResponseBase<PullConsentResult>> PullConsent(PullConsentRequest request);
+        Task<ResponseBase<PullConsentResult>> PullConsent(string companyCode);
     }
 }
 


### PR DESCRIPTION
## Summary
- fetch IYS and brand codes inside consent service using company code
- load pull consent limit/after values from appsettings and default source to IYS
- expose Salesforce consent endpoint alongside pull consent API
- run pull-consent and sf-consent worker processes from consent controller

## Testing
- `dotnet build IYSIntegration.sln`
- `dotnet test IYSIntegration.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b44f7a61b8832293fa7a538b321f2b