### PR TITLE
Load company codes from configuration

### DIFF
--- a/IYSIntegration.API/appsettings.Production.json
+++ b/IYSIntegration.API/appsettings.Production.json
@@ -14,6 +14,7 @@
   "RefreshTokenExpiresIn": "14400",
   "BaseUrl": "https://api.iys.org.tr",
   "LogPath": "D:\\Logs\\IYS\\API",
+  "CompanyCodes": [ "BOI", "BOP", "BOPK", "BOM" ],
   "BOI": {
     "IysCode": "679648",
     "BrandCode": "679648"

--- a/IYSIntegration.API/appsettings.json
+++ b/IYSIntegration.API/appsettings.json
@@ -14,7 +14,8 @@
   "MultipleConsentQueryCheckAfter": "60",
   "RefreshTokenExpiresIn": "14400",
   "BaseUrl": "https://api.sandbox.iys.org.tr",
-  "LogPath": "E:\\Logs\\IYS\\API",
+  "LogPath": "E\\Logs\\IYS\\API",
+  "CompanyCodes": [ "BOI", "BOP", "BOPK", "BOM" ],
   "BOI": {
     "IysCode": "681602",
     "BrandCode": "617653"

--- a/IYSIntegration.WorkerService/Services/MultipleConsentAddWorker.cs
+++ b/IYSIntegration.WorkerService/Services/MultipleConsentAddWorker.cs
@@ -44,7 +44,7 @@ namespace IYSIntegration.WorkerService.Services
                     var checkAfterInSeconds = _configuration.GetValue<int>("MultipleConsentQueryCheckAfter");
                     var batchSize = _configuration.GetValue<int>("MultipleConsentBatchSize");
 
-                    var companyList = new List<string> { "BOI", "BOP", "BOPK", "BOM" };
+                    var companyList = _configuration.GetSection("CompanyCodes").Get<List<string>>() ?? new List<string>();
                     foreach (var companyCode in companyList)
                     {
                         await _dbHelper.UpdateBatchId(companyCode, batchSize);

--- a/IYSIntegration.WorkerService/Services/PullConsentWorker.cs
+++ b/IYSIntegration.WorkerService/Services/PullConsentWorker.cs
@@ -37,7 +37,7 @@ namespace IYSIntegration.WorkerService.Services
                 {
                     _logger.LogInformation("ConsentPullWorker running at: {time}", DateTimeOffset.Now);
                     // TODO: 24 saatte 1 çalýuþacak þekilde kurgulanacak Gece 01:00 sonrasý
-                    var companyList = new List<string> { "BOI", "BOP", "BOPK", "BOM" };
+                    var companyList = _configuration.GetSection("CompanyCodes").Get<List<string>>() ?? new List<string>();
                     foreach (var companyCode in companyList)
                     {
                         companyCodeInProc = companyCode;

--- a/IYSIntegration.WorkerService/appsettings.json
+++ b/IYSIntegration.WorkerService/appsettings.json
@@ -9,6 +9,7 @@
   "ConnectionStrings": {
     "SfdcMasterData": "Data Source=DMMDPDBAL1;Initial Catalog=SfdcMasterData;uid=sfdcuser;pwd=sfdcuser123;Pooling=true; Max Pool Size=300"
   },
+  "CompanyCodes": [ "BOI", "BOP", "BOPK", "BOM" ],
   "BOI": {
     "IysCode": "679648",
     "BrandCode": "679648"


### PR DESCRIPTION
## Summary
- read company codes from `CompanyCodes` list in configuration instead of hardcoded values
- define shared `CompanyCodes` arrays in API and WorkerService appsettings

## Testing
- `dotnet build IYSIntegration.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b523e027d48322ae051b7dec8d7e14