### PR TITLE
Add proxy API for IYS consent operations

### DIFF
--- a/IYSIntegration.Proxy.API/Controllers/ProxyConsentController.cs
+++ b/IYSIntegration.Proxy.API/Controllers/ProxyConsentController.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using IYSIntegration.Application.Interface;
+using IYSIntegration.Common.Request.Consent;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IYSIntegration.Proxy.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]/{iysCode}/brands/{brandCode}")]
+    public class ProxyConsentController : ControllerBase
+    {
+        private readonly IConsentService _consentService;
+
+        public ProxyConsentController(IConsentService consentService)
+        {
+            _consentService = consentService;
+        }
+
+        [Route("consents")]
+        [HttpPost]
+        public async Task<IActionResult> AddConsent(int iysCode, int brandCode, [FromBody] Common.Base.Consent consent)
+        {
+            var request = new AddConsentRequest { IysCode = iysCode, BrandCode = brandCode, Consent = consent };
+            var result = await _consentService.AddConsent(request);
+            return Ok(result);
+        }
+
+        [Route("consents/status")]
+        [HttpPost]
+        public async Task<IActionResult> SearchConsent(int iysCode, int brandCode, [FromBody] Common.Base.RecipientKey recipientKey)
+        {
+            var request = new QueryConsentRequest { IysCode = iysCode, BrandCode = brandCode, RecipientKey = recipientKey };
+            var result = await _consentService.QueryConsent(request);
+            return Ok(result);
+        }
+
+        [Route("consents/request")]
+        [HttpPost]
+        public async Task<IActionResult> AddMultipleConsent(int iysCode, int brandCode, [FromBody] List<Common.Base.Consent> consents)
+        {
+            var request = new MultipleConsentRequest { IysCode = iysCode, BrandCode = brandCode, Consents = consents };
+            var result = await _consentService.AddMultipleConsent(request);
+            return Ok(result);
+        }
+
+        [Route("consents/request/{requestId}")]
+        [HttpGet]
+        public async Task<IActionResult> SearchMultipleConsent(int iysCode, int brandCode, string requestId)
+        {
+            var request = new QueryMultipleConsentRequest { IysCode = iysCode, BrandCode = brandCode, RequestId = requestId };
+            var result = await _consentService.QueryMultipleConsent(request);
+            return Ok(result);
+        }
+
+        [Route("consents/changes")]
+        [HttpGet]
+        public async Task<IActionResult> PullConsent(int iysCode, int brandCode, string after, int limit, string source)
+        {
+            var request = new PullConsentRequest { IysCode = iysCode, BrandCode = brandCode, After = after, Limit = limit, Source = source };
+            var result = await _consentService.PullConsent(request);
+            return Ok(result);
+        }
+    }
+}

--- a/IYSIntegration.Proxy.API/IYSIntegration.Proxy.API.csproj
+++ b/IYSIntegration.Proxy.API/IYSIntegration.Proxy.API.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IYSIntegration.Common\IYSIntegration.Common.csproj" />
+    <ProjectReference Include="..\IYSIntegration.Application\IYSIntegration.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/IYSIntegration.Proxy.API/Program.cs
+++ b/IYSIntegration.Proxy.API/Program.cs
@@ -1,0 +1,55 @@
+using IYSIntegration.Application.Interface;
+using IYSIntegration.Application.Services;
+using IYSIntegration.Common.Base;
+using IYSIntegration.Common.LoggingService;
+using IYSIntegration.Common.LoggingService.Loggers;
+using IYSIntegration.Common.Middleware.Exceptions;
+using IYSIntegration.Common.Services;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using StackExchange.Redis;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Logging
+builder.Services.AddSingleton<LoggerServiceBase>(_ => new GrayLogger());
+
+// Configuration
+builder.Services.Configure<CacheSettings>(builder.Configuration.GetSection("CacheSettings"));
+
+// Infrastructure
+builder.Services.AddSingleton<IConnectionMultiplexer>(sp =>
+{
+    var cacheSettings = sp.GetRequiredService<IOptions<CacheSettings>>().Value;
+    return ConnectionMultiplexer.Connect(cacheSettings.ConnectionString);
+});
+
+builder.Services.AddSingleton<ICacheService, CacheService>();
+
+// Domain services
+builder.Services.AddSingleton<IDbService, DbService>();
+builder.Services.AddSingleton<IIdentityService, IdentityService>();
+builder.Services.AddSingleton<ISfIdentityService, SfIdentityService>();
+builder.Services.AddSingleton<IRestClientService, RestClientService>();
+builder.Services.AddSingleton<IConsentService, ConsentService>();
+builder.Services.AddSingleton<ISfConsentService, SfConsentService>();
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "IYS Integration Proxy", Version = "v1" });
+});
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.UseMiddleware<ExceptionMiddleware>();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/IYSIntegration.Proxy.API/appsettings.json
+++ b/IYSIntegration.Proxy.API/appsettings.json
@@ -1,0 +1,88 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ConnectionStrings": {
+    "SfdcMasterData": "Data Source=dmmdvincdbt1;Initial Catalog=SfdcMasterData;uid=sfdcuser;pwd=;Pooling=true; Max Pool Size=300"
+    // "SfdcMasterData": "Data Source=DMMDPDBAL1;Initial Catalog=SfdcMasterData;uid=sfdcuser;pwd=;Pooling=true; Max Pool Size=300"
+  },
+  "AllowedHosts": "*",
+  "MultipleConsentQueryCheckAfter": "60",
+  "RefreshTokenExpiresIn": "14400",
+  "BaseUrl": "https://api.sandbox.iys.org.tr",
+  "LogPath": "E\\Logs\\IYS\\API",
+  "CompanyCodes": [ "BOI", "BOP", "BOPK", "BOM" ],
+  "BOI": {
+    "IysCode": "681602",
+    "BrandCode": "617653"
+  },
+  "BOP": {
+    "IysCode": "677344",
+    "BrandCode": "637446"
+  },
+  "BOPK": {
+    "IysCode": "618806",
+    "BrandCode": "604451"
+  },
+  "BOM": {
+    "IysCode": "123456",
+    "BrandCode": "123456"
+  },
+  "681602": {
+    "Username": "",
+    "Password": ""
+  },
+  "677344": {
+    "Username": "",
+    "Password": ""
+  },
+  "618806": {
+    "Username": "",
+    "Password": ""
+  },
+  "123456": {
+    "Username": "",
+    "Password": ""
+  },
+  "Salesforce": {
+    "BaseUrl": "https://borusanotomotiv--qa.my.salesforce.com/services"
+  },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Graylog" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System": "Warning",
+        "Microsoft.AspNetCore.Authentication": "Warning",
+        "Microsoft.EntityFrameworkCore.Model.Validation": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Graylog",
+        "Args": {
+          "hostnameOrAddress": "boazwegrylgd01.internal.borusan.com",
+          "minimumLogEventLevel": "Debug",
+          "port": "5353",
+          "transportType": "Udp"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId", "WithEnvironmentUserName", "WithEnvironmentName" ],
+    "Properties": {
+      "Application": "IYS.API"
+    }
+  },
+  "CacheSettings": {
+    "ConnectionString": "bomdvrdst01:6379", // Redis bağlantı
+    "SlidingExpiration": 1,
+    "Db": 1
+  }
+}

--- a/IYSIntegration.sln
+++ b/IYSIntegration.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IYSIntegration.API", "IYSIn
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IYSIntegration.Application", "IYSIntegration.Application\IYSIntegration.Application.csproj", "{E263ACBA-C55E-4E06-8F47-493D64FF2A16}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IYSIntegration.Proxy.API", "IYSIntegration.Proxy.API\IYSIntegration.Proxy.API.csproj", "{1608B4C0-09C3-42D2-A84A-F52FD476CD9B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,6 +36,12 @@ Global
 		{E263ACBA-C55E-4E06-8F47-493D64FF2A16}.Local Prod|Any CPU.Build.0 = Release|Any CPU
 		{E263ACBA-C55E-4E06-8F47-493D64FF2A16}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E263ACBA-C55E-4E06-8F47-493D64FF2A16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1608B4C0-09C3-42D2-A84A-F52FD476CD9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1608B4C0-09C3-42D2-A84A-F52FD476CD9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1608B4C0-09C3-42D2-A84A-F52FD476CD9B}.Local Prod|Any CPU.ActiveCfg = Debug|Any CPU
+		{1608B4C0-09C3-42D2-A84A-F52FD476CD9B}.Local Prod|Any CPU.Build.0 = Debug|Any CPU
+		{1608B4C0-09C3-42D2-A84A-F52FD476CD9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1608B4C0-09C3-42D2-A84A-F52FD476CD9B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ The following values from `appsettings.json` indicate how many minutes each dela
 - `SingleConsentQueryDelay` – 300 seconds (5 minutes)
 - `PullConsentQueryDelay` – 3600 seconds (60 minutes)
 - `SfAddConsentDelay` – 90 seconds (1.5 minutes)
+
+## Proxy API
+
+The `IYSIntegration.Proxy.API` project exposes consent endpoints that forward requests to IYS.
+Use this API as an alternate base URL for remote debugging when direct IYS access from local environments is blocked.


### PR DESCRIPTION
## Summary
- add `IYSIntegration.Proxy.API` project exposing proxy consent endpoints to forward to IYS
- update solution and docs to include proxy API

## Testing
- `dotnet restore IYSIntegration.sln`
- `dotnet build IYSIntegration.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b5efb321d4832290a9bf9dc06d224e