### PR TITLE
Fix config initialization in ScheduledSingleConsentAddService

### DIFF
--- a/IYSIntegration.Application/Services/ScheduledSingleConsentAddService.cs
+++ b/IYSIntegration.Application/Services/ScheduledSingleConsentAddService.cs
@@ -19,6 +19,7 @@ namespace IYSIntegration.Application.Services
 
         public ScheduledSingleConsentAddService(IConfiguration config, ILogger<ScheduledSingleConsentAddService> logger, IDbService dbHelper, IRestClientService clientHelper)
         {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
             _logger = logger;
             _dbService = dbHelper;
             _clientHelper = clientHelper;


### PR DESCRIPTION
## Summary
- ensure `_config` is assigned before being used in `ScheduledSingleConsentAddService`

## Testing
- `dotnet build IYSIntegration.sln`
- `dotnet run` (instantiate `ScheduledSingleConsentAddService` and `ScheduledController`)


------
https://chatgpt.com/codex/tasks/task_e_68b87011f6448322b5c3b21b5d479ab7