### PR TITLE
Fix configuration injection for ScheduledSingleConsentAddService

### DIFF
--- a/IYSIntegration.Application/Services/ScheduledSingleConsentAddService.cs
+++ b/IYSIntegration.Application/Services/ScheduledSingleConsentAddService.cs
@@ -19,6 +19,7 @@ namespace IYSIntegration.Application.Services
 
         public ScheduledSingleConsentAddService(IConfiguration config, ILogger<ScheduledSingleConsentAddService> logger, IDbService dbHelper, IRestClientService clientHelper)
         {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
             _logger = logger;
             _dbService = dbHelper;
             _clientHelper = clientHelper;


### PR DESCRIPTION
## Summary
- assign incoming configuration to `_config` before using it
- set `_baseProxyUrl` using the initialized configuration

## Testing
- `dotnet build IYSIntegration.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b874febef0832293d7c84c91540ef6