### PR TITLE
Use SimpleRestClient for pull-consent via IYSProxy

### DIFF
--- a/IYSIntegration.API/appsettings.json
+++ b/IYSIntegration.API/appsettings.json
@@ -14,6 +14,7 @@
   "MultipleConsentQueryCheckAfter": "60",
   "RefreshTokenExpiresIn": "14400",
   "BaseUrl": "https://api.sandbox.iys.org.tr",
+  "IysProxyBaseUrl": "http://bomdvdigip02/iysproxy/api/IYSProxy",
   "LogPath": "E\\Logs\\IYS\\API",
   "CompanyCodes": [ "BOI", "BOP", "BOPK", "BOM" ],
   "BOI": {

--- a/IYSIntegration.Application/Services/SimpleRestClient.cs
+++ b/IYSIntegration.Application/Services/SimpleRestClient.cs
@@ -1,0 +1,26 @@
+using IYSIntegration.Common.Base;
+using Newtonsoft.Json;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.Application.Services
+{
+    public class SimpleRestClient
+    {
+        private readonly HttpClient _httpClient;
+
+        public SimpleRestClient()
+        {
+            _httpClient = new HttpClient();
+        }
+
+        public async Task<ResponseBase<T>> GetAsync<T>(string url)
+        {
+            var httpResponse = await _httpClient.GetAsync(url);
+            var content = await httpResponse.Content.ReadAsStringAsync();
+            var response = JsonConvert.DeserializeObject<ResponseBase<T>>(content) ?? new ResponseBase<T>();
+            response.HttpStatusCode = (int)httpResponse.StatusCode;
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable IysProxyBaseUrl
- call IYSProxy pull-consent with new SimpleRestClient
- introduce SimpleRestClient for basic GET requests

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b8789bdfec8322a3bdc5e21b9fad78