### PR TITLE
Inject IysClient into scheduled consent services

### DIFF
--- a/IYSIntegration.API/Program.cs
+++ b/IYSIntegration.API/Program.cs
@@ -18,7 +18,7 @@ internal class Program
         builder.Services.AddScoped<IIysHelper, IysHelper>();
         builder.Services.AddSingleton<IDbService, DbService>();
         builder.Services.AddSingleton<SalesforceClient>();
-        builder.Services.AddSingleton<IysClient>();
+        builder.Services.AddSingleton<ISimpleRestClient, IysClient>();
 
         builder.Services.AddScoped<ScheduledMultipleConsentQueryService>();
         builder.Services.AddScoped<ScheduledSingleConsentAddService>();

--- a/IYSIntegration.Application/Services/ScheduledMultipleConsentAddService.cs
+++ b/IYSIntegration.Application/Services/ScheduledMultipleConsentAddService.cs
@@ -14,15 +14,15 @@ public class ScheduledMultipleConsentAddService
     private readonly ILogger<ScheduledMultipleConsentAddService> _logger;
     private readonly IDbService _dbService;
     private readonly IConfiguration _configuration;
-    private readonly IysClient _client;
+    private readonly ISimpleRestClient _client;
     private readonly SemaphoreSlim _semaphore = new(1, 1);
 
-    public ScheduledMultipleConsentAddService(IConfiguration configuration, ILogger<ScheduledMultipleConsentAddService> logger, IDbService dbHelper)
+    public ScheduledMultipleConsentAddService(IConfiguration configuration, ILogger<ScheduledMultipleConsentAddService> logger, IDbService dbHelper, ISimpleRestClient client)
     {
         _configuration = configuration;
         _logger = logger;
         _dbService = dbHelper;
-        _client = new IysClient(_configuration);
+        _client = client;
     }
 
     public async Task<ResponseBase<ScheduledJobStatistics>> RunAsync(int batchSize, int batchCount, int checkAfterInSeconds)

--- a/IYSIntegration.Application/Services/ScheduledSingleConsentAddService.cs
+++ b/IYSIntegration.Application/Services/ScheduledSingleConsentAddService.cs
@@ -3,7 +3,6 @@ using IYSIntegration.Application.Services.Models;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Request.Consent;
 using IYSIntegration.Application.Services.Models.Response.Consent;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 
@@ -14,16 +13,14 @@ public class ScheduledSingleConsentAddService
 {
     private readonly ILogger<ScheduledSingleConsentAddService> _logger;
     private readonly IDbService _dbService;
-    private readonly IConfiguration _config;
-    private readonly IysClient _client;
+    private readonly ISimpleRestClient _client;
     private readonly IIysHelper _iysHelper;
 
-    public ScheduledSingleConsentAddService(IConfiguration config, ILogger<ScheduledSingleConsentAddService> logger, IDbService dbHelper, IIysHelper iysHelper)
+    public ScheduledSingleConsentAddService(ILogger<ScheduledSingleConsentAddService> logger, IDbService dbHelper, ISimpleRestClient client, IIysHelper iysHelper)
     {
-        _config = config ?? throw new ArgumentNullException(nameof(config));
         _logger = logger;
         _dbService = dbHelper;
-        _client = new IysClient(_config);
+        _client = client;
         _iysHelper = iysHelper;
     }
 


### PR DESCRIPTION
## Summary
- inject REST client into scheduled consent add services instead of constructing `IysClient`
- register `IysClient` implementation for `ISimpleRestClient` in DI

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68bb1c6d4a648322b74529650d5f37aa