### PR TITLE
Propagate HTTP status codes from client helper

### DIFF
--- a/IYSIntegration.Proxy.API/Controllers/BrandsController.cs
+++ b/IYSIntegration.Proxy.API/Controllers/BrandsController.cs
@@ -1,4 +1,4 @@
-﻿using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Interface;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Request;
 using IYSIntegration.Application.Services.Models.Response.Brand;
@@ -29,17 +29,21 @@ public class BrandsController : ControllerBase
     /// <param name="companyCode"></param>
     /// <returns></returns>
     [HttpGet("GetAll")]
-    public async Task<ResponseBase<List<Brand>>> GetAll(
+    public async Task<ActionResult<ResponseBase<List<Brand>>>> GetAll(
         [FromRoute] string companyCode
         )
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<List<Brand>, DummyRequest>(new IysRequest<DummyRequest>
+        var iysRequest = new IysRequest<DummyRequest>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands",
             Action = "Get Brands"
-        });
+        };
+
+        var result = await _clientHelper.Execute<List<Brand>, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 }

--- a/IYSIntegration.Proxy.API/Controllers/ConsentsController.cs
+++ b/IYSIntegration.Proxy.API/Controllers/ConsentsController.cs
@@ -1,4 +1,4 @@
-﻿using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Interface;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Request;
 using IYSIntegration.Application.Services.Models.Request.Consent;
@@ -31,20 +31,24 @@ public class ConsentsController : ControllerBase
     /// <param name="consent"></param>
     /// <returns></returns>
     [HttpPost("addConsent")]
-    public async Task<ResponseBase<AddConsentResult>> AddConsent(
+    public async Task<ActionResult<ResponseBase<AddConsentResult>>> AddConsent(
         [FromRoute] string companyCode,
         [FromBody] Consent consent)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<AddConsentResult, Consent>(new IysRequest<Consent>
+        var iysRequest = new IysRequest<Consent>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consents",
             Body = consent,
             Action = "Add Consent",
             Method = RestSharp.Method.Post
-        });
+        };
+
+        var result = await _clientHelper.Execute<AddConsentResult, Consent>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -54,20 +58,24 @@ public class ConsentsController : ControllerBase
     /// <param name="recipientKey"></param>
     /// <returns></returns>
     [HttpPost("queryConsent")]
-    public async Task<ResponseBase<QueryConsentResult>> QueryConsent(
+    public async Task<ActionResult<ResponseBase<QueryConsentResult>>> QueryConsent(
         [FromRoute] string companyCode,
         [FromBody] RecipientKey recipientKey)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<QueryConsentResult, RecipientKey>(new IysRequest<RecipientKey>
+        var iysRequest = new IysRequest<RecipientKey>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consents/status",
             Body = recipientKey,
             Action = "Query Consent",
             Method = RestSharp.Method.Post
-        });
+        };
+
+        var result = await _clientHelper.Execute<QueryConsentResult, RecipientKey>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -77,20 +85,24 @@ public class ConsentsController : ControllerBase
     /// <param name="request"></param>
     /// <returns></returns>
     [HttpPost("addMultipleConsent")]
-    public async Task<ResponseBase<MultipleConsentResult>> AddMultipleConsent(
+    public async Task<ActionResult<ResponseBase<MultipleConsentResult>>> AddMultipleConsent(
         [FromRoute] string companyCode,
         [FromBody] MultipleConsentRequest request)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<MultipleConsentResult, List<Consent>>(new IysRequest<List<Consent>>
+        var iysRequest = new IysRequest<List<Consent>>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consents/request",
             Body = request.Consents,
             Action = "Add Multiple Consent",
             BatchId = request.BatchId
-        });
+        };
+
+        var result = await _clientHelper.Execute<MultipleConsentResult, List<Consent>>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -101,19 +113,23 @@ public class ConsentsController : ControllerBase
     /// <param name="batchId"></param>
     /// <returns></returns>
     [HttpGet("queryMultipleConsent")]
-    public async Task<ResponseBase<List<QueryMultipleConsentResult>>> QueryMultipleConsent(
+    public async Task<ActionResult<ResponseBase<List<QueryMultipleConsentResult>>>> QueryMultipleConsent(
         [FromRoute] string companyCode,
         [FromQuery] string requestId, int? batchId = null)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<List<QueryMultipleConsentResult>, DummyRequest>(new IysRequest<DummyRequest>
+        var iysRequest = new IysRequest<DummyRequest>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consents/request/{Uri.EscapeDataString(requestId)}",
             Action = "Query Multiple Consent",
             BatchId = batchId
-        });
+        };
+
+        var result = await _clientHelper.Execute<List<QueryMultipleConsentResult>, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>

--- a/IYSIntegration.Proxy.API/Controllers/InfoController.cs
+++ b/IYSIntegration.Proxy.API/Controllers/InfoController.cs
@@ -1,4 +1,4 @@
-﻿using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Interface;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Request;
 using Microsoft.AspNetCore.Mvc;
@@ -23,50 +23,70 @@ public class InfoController : ControllerBase
     }
 
     [HttpGet("getCities")]
-    public async Task<ResponseBase<List<City>>> GetCities([FromRoute] string companyCode)
+    public async Task<ActionResult<ResponseBase<List<City>>>> GetCities([FromRoute] string companyCode)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
-        return await _clientHelper.Execute<List<City>, DummyRequest>(new IysRequest<DummyRequest>
+
+        var iysRequest = new IysRequest<DummyRequest>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/info/cities",
             Action = "Get Cities"
-        });
+        };
+
+        var result = await _clientHelper.Execute<List<City>, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     [HttpGet("getCity")]
-    public async Task<ResponseBase<City>> GetCity([FromRoute] string companyCode, [FromQuery] string code)
+    public async Task<ActionResult<ResponseBase<City>>> GetCity([FromRoute] string companyCode, [FromQuery] string code)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
-        return await _clientHelper.Execute<City, DummyRequest>(new IysRequest<DummyRequest>
+
+        var iysRequest = new IysRequest<DummyRequest>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/info/cities/{code}",
             Action = "Get City"
-        });
+        };
+
+        var result = await _clientHelper.Execute<City, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     [HttpGet("getTown")]
-    public async Task<ResponseBase<Town>> GetTown([FromRoute] string companyCode, [FromQuery] string townCode)
+    public async Task<ActionResult<ResponseBase<Town>>> GetTown([FromRoute] string companyCode, [FromQuery] string townCode)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
-        return await _clientHelper.Execute<Town, DummyRequest>(new IysRequest<DummyRequest>
+
+        var iysRequest = new IysRequest<DummyRequest>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/info/town/{townCode}",
             Action = "Get Town"
-        });
+        };
+
+        var result = await _clientHelper.Execute<Town, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     [HttpGet("getTowns")]
-    public async Task<ResponseBase<List<Town>>> GetTowns([FromRoute] string companyCode)
+    public async Task<ActionResult<ResponseBase<List<Town>>>> GetTowns([FromRoute] string companyCode)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
-        return await _clientHelper.Execute<List<Town>, DummyRequest>(new IysRequest<DummyRequest>
+
+        var iysRequest = new IysRequest<DummyRequest>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/info/town",
             Action = "Get Towns"
-        });
+        };
+
+        var result = await _clientHelper.Execute<List<Town>, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 }

--- a/IYSIntegration.Proxy.API/Controllers/RetailersAccessController.cs
+++ b/IYSIntegration.Proxy.API/Controllers/RetailersAccessController.cs
@@ -1,4 +1,4 @@
-﻿using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Interface;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Request.RetailerAccess;
 using IYSIntegration.Application.Services.Models.Response.RetailerAccess;
@@ -30,19 +30,23 @@ public class RetailersAccessController : ControllerBase
     /// <param name="request"></param>
     /// <returns></returns>
     [HttpPost("addRetailerAccess")]
-    public async Task<ResponseBase<AddRetailerAccessResult>> AddRetailerAccess(
+    public async Task<ActionResult<ResponseBase<AddRetailerAccessResult>>> AddRetailerAccess(
         [FromRoute] string companyCode,
         [FromBody] RetailerRecipientAccess request)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<AddRetailerAccessResult, RetailerRecipientAccess>(new IysRequest<RetailerRecipientAccess>
+        var iysRequest = new IysRequest<RetailerRecipientAccess>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consents/retailers/access",
             Body = request,
             Action = "Add Retailer Access"
-        });
+        };
+
+        var result = await _clientHelper.Execute<AddRetailerAccessResult, RetailerRecipientAccess>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -52,20 +56,24 @@ public class RetailersAccessController : ControllerBase
     /// <param name="request"></param>
     /// <returns></returns>
     [HttpPost("deleteAllRetailersAccess")]
-    public async Task<ResponseBase<DeleteAllRetailersAccessResult>> DeleteAllRetailersAccess(
+    public async Task<ActionResult<ResponseBase<DeleteAllRetailersAccessResult>>> DeleteAllRetailersAccess(
         [FromRoute] string companyCode,
         [FromBody] RetailerRecipientAccess request
         )
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<DeleteAllRetailersAccessResult, RetailerRecipientAccess>(new IysRequest<RetailerRecipientAccess>
+        var iysRequest = new IysRequest<RetailerRecipientAccess>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consents/retailers/access/remove/all",
             Body = request,
             Action = "Delete All Retailers Access"
-        });
+        };
+
+        var result = await _clientHelper.Execute<DeleteAllRetailersAccessResult, RetailerRecipientAccess>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -75,20 +83,24 @@ public class RetailersAccessController : ControllerBase
     /// <param name="request"></param>
     /// <returns></returns>
     [HttpPost("updateRetailerAccess")]
-    public async Task<ResponseBase<UpdateRetailerAccessResult>> UpdateRetailerAccess(
+    public async Task<ActionResult<ResponseBase<UpdateRetailerAccessResult>>> UpdateRetailerAccess(
         [FromRoute] string companyCode,
         [FromBody] RetailerRecipientAccess request
         )
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<UpdateRetailerAccessResult, RetailerRecipientAccess>(new IysRequest<RetailerRecipientAccess>
+        var iysRequest = new IysRequest<RetailerRecipientAccess>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consents/retailers/access",
             Body = request,
             Action = "Update Retailer Access"
-        });
+        };
+
+        var result = await _clientHelper.Execute<UpdateRetailerAccessResult, RetailerRecipientAccess>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -97,7 +109,7 @@ public class RetailersAccessController : ControllerBase
     /// <param name="request"></param>
     /// <returns></returns>
     [HttpPost("deleteRetailerAccess")]
-    public async Task<ResponseBase<DeleteRetailerAccessResult>> DeleteRetailerAccess(DeleteRetailerAccessRequest request)
+    public async Task<ActionResult<ResponseBase<DeleteRetailerAccessResult>>> DeleteRetailerAccess(DeleteRetailerAccessRequest request)
     {
         var iysRequest = new IysRequest<RetailerRecipientAccess>
         {
@@ -107,7 +119,9 @@ public class RetailersAccessController : ControllerBase
             Action = "Delete Retailer Access"
         };
 
-        return await _clientHelper.Execute<DeleteRetailerAccessResult, RetailerRecipientAccess>(iysRequest);
+        var result = await _clientHelper.Execute<DeleteRetailerAccessResult, RetailerRecipientAccess>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -117,20 +131,23 @@ public class RetailersAccessController : ControllerBase
     /// <param name="request"></param>
     /// <returns></returns>
     [HttpPost("queryRetailerAccess")]
-    public async Task<ResponseBase<QueryRetailerAccessResult>> QueryRetailerAccess(
+    public async Task<ActionResult<ResponseBase<QueryRetailerAccessResult>>> QueryRetailerAccess(
         [FromRoute] string companyCode,
         [FromBody] RecipientKey request
         )
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<QueryRetailerAccessResult, RecipientKey>(new IysRequest<RecipientKey>
+        var iysRequest = new IysRequest<RecipientKey>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consent/retailers/access/list",
             Body = request,
             Action = "Query Retailer Access"
-        });
-    }
+        };
 
+        var result = await _clientHelper.Execute<QueryRetailerAccessResult, RecipientKey>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
+    }
 }

--- a/IYSIntegration.Proxy.API/Controllers/RetailersController.cs
+++ b/IYSIntegration.Proxy.API/Controllers/RetailersController.cs
@@ -1,4 +1,4 @@
-﻿using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Interface;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Request;
 using IYSIntegration.Application.Services.Models.Response.Retailer;
@@ -30,20 +30,23 @@ public class RetailersController : ControllerBase
     /// <param name="retailer"></param>
     /// <returns></returns>
     [HttpPost("addRetailer")]
-    public async Task<ResponseBase<AddRetailerResponse>> AddConsent(
+    public async Task<ActionResult<ResponseBase<AddRetailerResponse>>> AddConsent(
         [FromRoute] string companyCode,
         [FromBody] Retailer retailer)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<AddRetailerResponse, Retailer>(new IysRequest<Retailer>
+        var iysRequest = new IysRequest<Retailer>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/retailers",
             Body = retailer,
             Action = "Add Retailer"
-        });
+        };
 
+        var result = await _clientHelper.Execute<AddRetailerResponse, Retailer>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -53,19 +56,23 @@ public class RetailersController : ControllerBase
     /// <param name="retailerCode"></param>
     /// <returns></returns>
     [HttpGet("getRetailer")]
-    public async Task<ResponseBase<GetRetailerResponse>> GetRetailer(
+    public async Task<ActionResult<ResponseBase<GetRetailerResponse>>> GetRetailer(
         [FromRoute] string companyCode,
         [FromQuery] string retailerCode
         )
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<GetRetailerResponse, DummyRequest>(new IysRequest<DummyRequest>
+        var iysRequest = new IysRequest<DummyRequest>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/retailers/{retailerCode}",
             Action = "Get Retailer"
-        });
+        };
+
+        var result = await _clientHelper.Execute<GetRetailerResponse, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -74,16 +81,20 @@ public class RetailersController : ControllerBase
     /// <param name="companyCode"></param>
     /// <returns></returns>
     [HttpGet("getAllRetailers")]
-    public async Task<ResponseBase<GetAllRetailersResponse>> GetAllRetailers([FromRoute] string companyCode)
+    public async Task<ActionResult<ResponseBase<GetAllRetailersResponse>>> GetAllRetailers([FromRoute] string companyCode)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<GetAllRetailersResponse, DummyRequest>(new IysRequest<DummyRequest>
+        var iysRequest = new IysRequest<DummyRequest>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/retailers",
             Action = "Get All Retailers"
-        });
+        };
+
+        var result = await _clientHelper.Execute<GetAllRetailersResponse, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
 
     /// <summary>
@@ -93,19 +104,21 @@ public class RetailersController : ControllerBase
     /// <param name="retailerCode"></param>
     /// <returns></returns>
     [HttpGet("deleteRetailer")]
-    public async Task<ResponseBase<DeleteRetailerResponse>> DeleteRetailer(
+    public async Task<ActionResult<ResponseBase<DeleteRetailerResponse>>> DeleteRetailer(
         [FromRoute] string companyCode,
         [FromQuery] string retailerCode)
     {
         var consentParams = _iysHelper.GetIysCode(companyCode);
 
-        return await _clientHelper.Execute<DeleteRetailerResponse, DummyRequest>(new IysRequest<DummyRequest>
+        var iysRequest = new IysRequest<DummyRequest>
         {
             IysCode = consentParams.IysCode,
             Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/retailers/{retailerCode}",
             Action = "Delete Retailer"
-        });
+        };
+
+        var result = await _clientHelper.Execute<DeleteRetailerResponse, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
-
-
 }


### PR DESCRIPTION
## Summary
- return `ActionResult<ResponseBase<T>>` in Proxy API controllers
- surface HTTP status codes from `IIysRestClientService` results via `StatusCode`

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68beb24878c48322a7d868df37f6ad40