### PR TITLE
Refine single consent processing and bulk logging

### DIFF
--- a/IYSIntegration.Application/Services/Interface/IDbService.cs
+++ b/IYSIntegration.Application/Services/Interface/IDbService.cs
@@ -23,6 +23,7 @@ namespace IYSIntegration.Application.Services.Interface
         Task InsertBatchConsentQuery(BatchConsentQuery request);
         Task<List<ConsentRequestLog>> GetConsentRequests(bool isProcessed, int rowCount);
         Task UpdateConsentResponse(ResponseBase<AddConsentResult> response);
+        Task UpdateConsentResponses(IEnumerable<ResponseBase<AddConsentResult>> responses);
         Task UpdateBatchId(string companyCode, int batchSize);
         Task<List<BatchSummary>> GetBatchSummary(int batchCount);
         Task<List<ConsentRequestLog>> GeBatchConsentRequests(int batchId);


### PR DESCRIPTION
## Summary
- batch consent response persistence in ScheduledSingleConsentAddService to avoid per-item database writes
- add bulk UpdateConsentResponses flow in DbService and expose it on IDbService
- surface detailed query errors and guard against logging insert fallback while keeping counts accurate

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cba995c55c8322b94f7f01d4ea2c7a