### PR TITLE
Add services to manage pending and overdue consents

### DIFF
--- a/IYSIntegration.Application/Services/DbService.cs
+++ b/IYSIntegration.Application/Services/DbService.cs
@@ -327,6 +327,19 @@ namespace IYSIntegration.Application.Services
 
         }
 
+        public async Task<List<ConsentRequestLog>> GetPendingConsentsWithoutPull(int rowCount)
+        {
+            using (var connection = new SqlConnection(_configuration.GetValue<string>("ConnectionStrings:SfdcMasterData")))
+            {
+                connection.Open();
+                var result = (await connection.QueryAsync<ConsentRequestLog>(string.Format(QueryStrings.GetPendingConsentsWithoutPull, rowCount))).ToList();
+                connection.Close();
+
+                return result;
+            }
+
+        }
+
         public async Task UpdateBatchId(string companyCode, int batchSize)
         {
             using (var connection = new SqlConnection(_configuration.GetValue<string>("ConnectionStrings:SfdcMasterData")))
@@ -644,6 +657,30 @@ namespace IYSIntegration.Application.Services
                 connection.Close();
 
                 return result;
+            }
+        }
+
+        public async Task<int> MarkConsentsOverdue(int maxAgeInDays)
+        {
+            using (var connection = new SqlConnection(_configuration.GetValue<string>("ConnectionStrings:SfdcMasterData")))
+            {
+                connection.Open();
+                var affected = await connection.ExecuteAsync(QueryStrings.MarkConsentsOverdue, new { MaxAgeInDays = maxAgeInDays });
+                connection.Close();
+
+                return affected;
+            }
+        }
+
+        public async Task<int> MarkDuplicateConsentsOverdue()
+        {
+            using (var connection = new SqlConnection(_configuration.GetValue<string>("ConnectionStrings:SfdcMasterData")))
+            {
+                connection.Open();
+                var affected = await connection.ExecuteAsync(QueryStrings.MarkDuplicateConsentsOverdue);
+                connection.Close();
+
+                return affected;
             }
         }
     }

--- a/IYSIntegration.Application/Services/Interface/IDbService.cs
+++ b/IYSIntegration.Application/Services/Interface/IDbService.cs
@@ -22,6 +22,7 @@ namespace IYSIntegration.Application.Services.Interface
         Task<int> InsertConsentRequestWithBatch(AddConsentRequest request);
         Task InsertBatchConsentQuery(BatchConsentQuery request);
         Task<List<ConsentRequestLog>> GetConsentRequests(bool isProcessed, int rowCount);
+        Task<List<ConsentRequestLog>> GetPendingConsentsWithoutPull(int rowCount);
         Task UpdateConsentResponse(ResponseBase<AddConsentResult> response);
         Task UpdateConsentResponses(IEnumerable<ResponseBase<AddConsentResult>> responses);
         Task UpdateBatchId(string companyCode, int batchSize);
@@ -40,5 +41,7 @@ namespace IYSIntegration.Application.Services.Interface
         Task UpdateSfConsentResponse(SfConsentResult consentResult);
         Task<List<Consent>> GetIYSConsentRequestErrors(DateTime? date = null);
         Task<T> UpdateLogFromResponseBase<T>(ResponseBase<T> response, int id);
+        Task<int> MarkConsentsOverdue(int maxAgeInDays);
+        Task<int> MarkDuplicateConsentsOverdue();
     }
 }

--- a/IYSIntegration.Application/Services/ScheduledConsentOverdueService.cs
+++ b/IYSIntegration.Application/Services/ScheduledConsentOverdueService.cs
@@ -1,0 +1,47 @@
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models;
+using IYSIntegration.Application.Services.Models.Base;
+using Microsoft.Extensions.Logging;
+
+namespace IYSIntegration.Application.Services
+{
+    public class ScheduledConsentOverdueService
+    {
+        private readonly ILogger<ScheduledConsentOverdueService> _logger;
+        private readonly IDbService _dbService;
+
+        public ScheduledConsentOverdueService(
+            ILogger<ScheduledConsentOverdueService> logger,
+            IDbService dbService)
+        {
+            _logger = logger;
+            _dbService = dbService;
+        }
+
+        public async Task<ResponseBase<ScheduledJobStatistics>> RunAsync(int maxAgeInDays = 3)
+        {
+            var response = new ResponseBase<ScheduledJobStatistics>();
+            response.Success();
+
+            try
+            {
+                var affected = await _dbService.MarkConsentsOverdue(maxAgeInDays);
+
+                response.Data = new ScheduledJobStatistics
+                {
+                    SuccessCount = affected,
+                    FailedCount = 0
+                };
+
+                response.AddMessage("OverdueMarked", affected.ToString());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Pending consents could not be marked as overdue.");
+                response.Error("OVERDUE_MARK_FAILED", "Bekleyen kayıtlar gecikmiş olarak işaretlenemedi.");
+            }
+
+            return response;
+        }
+    }
+}

--- a/IYSIntegration.Application/Services/ScheduledDuplicateConsentCleanupService.cs
+++ b/IYSIntegration.Application/Services/ScheduledDuplicateConsentCleanupService.cs
@@ -1,0 +1,47 @@
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models;
+using IYSIntegration.Application.Services.Models.Base;
+using Microsoft.Extensions.Logging;
+
+namespace IYSIntegration.Application.Services
+{
+    public class ScheduledDuplicateConsentCleanupService
+    {
+        private readonly ILogger<ScheduledDuplicateConsentCleanupService> _logger;
+        private readonly IDbService _dbService;
+
+        public ScheduledDuplicateConsentCleanupService(
+            ILogger<ScheduledDuplicateConsentCleanupService> logger,
+            IDbService dbService)
+        {
+            _logger = logger;
+            _dbService = dbService;
+        }
+
+        public async Task<ResponseBase<ScheduledJobStatistics>> RunAsync()
+        {
+            var response = new ResponseBase<ScheduledJobStatistics>();
+            response.Success();
+
+            try
+            {
+                var affected = await _dbService.MarkDuplicateConsentsOverdue();
+
+                response.Data = new ScheduledJobStatistics
+                {
+                    SuccessCount = affected,
+                    FailedCount = 0
+                };
+
+                response.AddMessage("DuplicatesMarked", affected.ToString());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Duplicate consent cleanup failed.");
+                response.Error("DUPLICATE_MARK_FAILED", "Tekrarlanan kayıtlar gecikmiş olarak işaretlenemedi.");
+            }
+
+            return response;
+        }
+    }
+}

--- a/IYSIntegration.Application/Services/ScheduledPendingConsentSyncService.cs
+++ b/IYSIntegration.Application/Services/ScheduledPendingConsentSyncService.cs
@@ -1,0 +1,213 @@
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models;
+using IYSIntegration.Application.Services.Models.Base;
+using IYSIntegration.Application.Services.Models.Request.Consent;
+using IYSIntegration.Application.Services.Models.Response.Consent;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace IYSIntegration.Application.Services
+{
+    public class ScheduledPendingConsentSyncService
+    {
+        private readonly ILogger<ScheduledPendingConsentSyncService> _logger;
+        private readonly IDbService _dbService;
+        private readonly IysProxy _client;
+        private readonly IIysHelper _iysHelper;
+
+        public ScheduledPendingConsentSyncService(
+            ILogger<ScheduledPendingConsentSyncService> logger,
+            IDbService dbService,
+            IysProxy client,
+            IIysHelper iysHelper)
+        {
+            _logger = logger;
+            _dbService = dbService;
+            _client = client;
+            _iysHelper = iysHelper;
+        }
+
+        public async Task<ResponseBase<ScheduledJobStatistics>> RunAsync(int rowCount)
+        {
+            var response = new ResponseBase<ScheduledJobStatistics>();
+            response.Success();
+
+            var results = new ConcurrentBag<LogResult>();
+            int successCount = 0;
+            int failedCount = 0;
+
+            try
+            {
+                var pendingRequests = await _dbService.GetPendingConsentsWithoutPull(rowCount);
+                var processedRecipients = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var consentParamsCache = new Dictionary<string, ConsentParams>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var request in pendingRequests)
+                {
+                    var companyCode = !string.IsNullOrWhiteSpace(request.CompanyCode)
+                        ? request.CompanyCode
+                        : _iysHelper.GetCompanyCode(request.IysCode) ?? string.Empty;
+
+                    if (string.IsNullOrWhiteSpace(companyCode))
+                    {
+                        results.Add(new LogResult
+                        {
+                            Id = request.Id,
+                            CompanyCode = string.Empty,
+                            Messages = new Dictionary<string, string>
+                            {
+                                { "Company", "Şirket kodu bulunamadı." }
+                            }
+                        });
+                        Interlocked.Increment(ref failedCount);
+                        continue;
+                    }
+
+                    var recipientKey = $"{companyCode}|{request.Recipient}|{request.RecipientType ?? string.Empty}";
+                    if (!processedRecipients.Add(recipientKey))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        var queryRequest = new RecipientKey
+                        {
+                            Recipient = request.Recipient,
+                            RecipientType = request.RecipientType,
+                            Type = request.Type
+                        };
+
+                        var queryResponse = await _client.PostJsonAsync<RecipientKey, QueryConsentResult>(
+                            $"consents/{companyCode}/queryConsent",
+                            queryRequest);
+
+                        if (queryResponse.IsSuccessful()
+                            && queryResponse.Data != null
+                            && !string.IsNullOrWhiteSpace(queryResponse.Data.ConsentDate))
+                        {
+                            if (!consentParamsCache.TryGetValue(companyCode, out var consentParams))
+                            {
+                                consentParams = request.IysCode != 0 && request.BrandCode != 0
+                                    ? new ConsentParams { IysCode = request.IysCode, BrandCode = request.BrandCode }
+                                    : _iysHelper.GetIysCode(companyCode);
+                                consentParamsCache[companyCode] = consentParams;
+                            }
+
+                            var insertRequest = new AddConsentRequest
+                            {
+                                CompanyCode = companyCode,
+                                IysCode = consentParams.IysCode,
+                                BrandCode = consentParams.BrandCode,
+                                Consent = new Consent
+                                {
+                                    Recipient = queryResponse.Data.Recipient,
+                                    Type = queryResponse.Data.Type,
+                                    Source = queryResponse.Data.Source,
+                                    Status = queryResponse.Data.Status,
+                                    ConsentDate = queryResponse.Data.ConsentDate,
+                                    RecipientType = queryResponse.Data.RecipientType,
+                                    CreationDate = queryResponse.Data.CreationDate,
+                                    TransactionId = queryResponse.Data.TransactionId
+                                }
+                            };
+
+                            await _dbService.InsertPullConsent(insertRequest);
+                            Interlocked.Increment(ref successCount);
+                        }
+                        else
+                        {
+                            results.Add(new LogResult
+                            {
+                                Id = request.Id,
+                                CompanyCode = companyCode,
+                                Messages = new Dictionary<string, string>
+                                {
+                                    { "Query Error", BuildErrorMessage(queryResponse) }
+                                }
+                            });
+                            Interlocked.Increment(ref failedCount);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Pending consent sync error for recipient {Recipient}", request.Recipient);
+                        results.Add(new LogResult
+                        {
+                            Id = request.Id,
+                            CompanyCode = companyCode,
+                            Messages = new Dictionary<string, string>
+                            {
+                                { "Exception", ex.Message }
+                            }
+                        });
+                        Interlocked.Increment(ref failedCount);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Fatal error in ScheduledPendingConsentSyncService");
+                results.Add(new LogResult
+                {
+                    Id = 0,
+                    CompanyCode = string.Empty,
+                    Messages = new Dictionary<string, string>
+                    {
+                        { "Exception", ex.Message }
+                    }
+                });
+                response.Error("PENDING_CONSENT_SYNC_FAILED", "Servis beklenmeyen bir hata nedeniyle sonlandı.");
+            }
+
+            foreach (var result in results)
+            {
+                response.AddMessage(result.GetMessages());
+            }
+
+            response.Data = new ScheduledJobStatistics
+            {
+                SuccessCount = successCount,
+                FailedCount = failedCount
+            };
+
+            return response;
+        }
+
+        private static string BuildErrorMessage<T>(ResponseBase<T> response)
+        {
+            var parts = new List<string>();
+
+            if (response.Messages is { Count: > 0 })
+            {
+                parts.AddRange(response.Messages.Select(kv => $"{kv.Key}: {kv.Value}"));
+            }
+
+            if (!string.IsNullOrWhiteSpace(response.OriginalError?.Message))
+            {
+                parts.Add($"Message: {response.OriginalError.Message}");
+            }
+
+            if (response.OriginalError?.Errors != null && response.OriginalError.Errors.Length > 0)
+            {
+                parts.AddRange(response.OriginalError.Errors
+                    .Where(e => !string.IsNullOrWhiteSpace(e.Code) || !string.IsNullOrWhiteSpace(e.Message))
+                    .Select(e => string.IsNullOrWhiteSpace(e.Code)
+                        ? e.Message ?? string.Empty
+                        : string.IsNullOrWhiteSpace(e.Message)
+                            ? e.Code
+                            : $"{e.Code}: {e.Message}"));
+            }
+
+            if (parts.Count == 0)
+            {
+                parts.Add($"HTTP {response.HttpStatusCode}");
+            }
+
+            return string.Join(" | ", parts);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add scheduled services that backfill pending consents, mark overdue requests, and clean up duplicates
- extend database layer with queries for overdue detection, duplicate handling, and pending pull lookups
- simplify the single-consent worker to only process non-overdue, unsent requests

## Testing
- dotnet build IYSIntegration.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cbaecbb24083229e2add3f39f6c1d5