### PR TITLE
Add addMultipleConsent v2 support

### DIFF
--- a/IYSIntegration.API/Controllers/CommonController.cs
+++ b/IYSIntegration.API/Controllers/CommonController.cs
@@ -213,6 +213,8 @@ namespace IYSIntegration.API.Controllers
                         RecipientType = consent.RecipientType,
                         Status = consent.Status,
                         Type = consent.Type,
+                        RetailerCode = consent.RetailerCode,
+                        RetailerAccess = consent.RetailerAccess,
                     }
                 };
 
@@ -223,6 +225,16 @@ namespace IYSIntegration.API.Controllers
             response.AddMessage("Success", $"{count}/{requestCount} kayıt başarı ile eklendi");
             response.Success();
             return response;
+        }
+
+        [Route("addMultipleConsentV2")]
+        [HttpPost]
+        public async Task<ResponseBase<MultipleConsentResult>> AddMultipleConsentV2([FromBody] MultipleConsentRequest request)
+        {
+            if (string.IsNullOrEmpty(request.CompanyCode))
+                request.CompanyCode = _iysHelper.GetCompanyCode(request.IysCode);
+
+            return await _client.PostJsonAsync<MultipleConsentRequest, MultipleConsentResult>($"consents/{request.CompanyCode}/addMultipleConsentV2", request);
         }
 
         [Route("sendMultipleConsent")]

--- a/IYSIntegration.Application/Services/Models/Base/Consent.cs
+++ b/IYSIntegration.Application/Services/Models/Base/Consent.cs
@@ -22,8 +22,8 @@ namespace IYSIntegration.Application.Services.Models.Base
         [JsonProperty("recipientType")]
         public string RecipientType { get; set; }
 
-        [JsonProperty("totalCount", NullValueHandling = NullValueHandling.Ignore)]
-        public int RetailerCode { get; set; }
+        [JsonProperty("retailerCode", NullValueHandling = NullValueHandling.Ignore)]
+        public int? RetailerCode { get; set; }
 
         [JsonProperty("creationDate", NullValueHandling = NullValueHandling.Ignore)]
         public string? CreationDate { get; set; }

--- a/IYSIntegration.Application/Services/Models/Response/Consent/SubRequest.cs
+++ b/IYSIntegration.Application/Services/Models/Response/Consent/SubRequest.cs
@@ -24,5 +24,8 @@ namespace IYSIntegration.Application.Services.Models.Response.Consent
 
         [JsonProperty("subRequestId")]
         public string SubRequestId { get; set; }
+
+        [JsonProperty("creationDate", NullValueHandling = NullValueHandling.Ignore)]
+        public string? CreationDate { get; set; }
     }
 }

--- a/IYSIntegration.Application/Services/ScheduledMultipleConsentAddService.cs
+++ b/IYSIntegration.Application/Services/ScheduledMultipleConsentAddService.cs
@@ -58,7 +58,9 @@ public class ScheduledMultipleConsentAddService
                             RecipientType = x.RecipientType,
                             Source = x.Source,
                             Status = x.Status,
-                            Type = x.Type
+                            Type = x.Type,
+                            RetailerCode = x.RetailerCode,
+                            RetailerAccess = x.RetailerAccess
                         }).ToList();
 
                         var result = await _client.PostJsonAsync<List<Consent>, MultipleConsentResult>($"consents/{companyCode}/multipleConsent", consents);

--- a/IYSIntegration.Proxy.API/Controllers/ConsentsController.cs
+++ b/IYSIntegration.Proxy.API/Controllers/ConsentsController.cs
@@ -106,6 +106,33 @@ public class ConsentsController : ControllerBase
     }
 
     /// <summary>
+    /// "{_baseUrl}/v2/sps/{IysCode}/brands/{BrandCode}/consents/request"
+    /// </summary>
+    /// <param name="companyCode"></param>
+    /// <param name="request"></param>
+    /// <returns></returns>
+    [HttpPost("addMultipleConsentV2")]
+    public async Task<ActionResult<ResponseBase<MultipleConsentResult>>> AddMultipleConsentV2(
+        [FromRoute] string companyCode,
+        [FromBody] MultipleConsentRequest request)
+    {
+        var consentParams = _iysHelper.GetIysCode(companyCode);
+
+        var iysRequest = new IysRequest<List<Consent>>
+        {
+            IysCode = consentParams.IysCode,
+            Url = $"{_baseUrl}/v2/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consents/request",
+            Body = request.Consents,
+            Action = "Add Multiple Consent V2",
+            BatchId = request.BatchId
+        };
+
+        var result = await _clientHelper.Execute<MultipleConsentResult, List<Consent>>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
+    }
+
+    /// <summary>
     /// "{_baseUrl}/sps/{IysCode}/brands/{BrandCode}/consents/request/{requestId}"
     /// </summary>
     /// <param name="companyCode"></param>


### PR DESCRIPTION
## Summary
- expose a CommonController endpoint that forwards addMultipleConsentV2 requests and preserve retailer details when queueing consents
- allow the scheduler to send retailer data and read creationDate from v2 responses
- add a proxy route for the IYS v2 batch consent endpoint while fixing the retailerCode payload mapping

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbac5f38c8322a58cf9acbab366c8