### PR TITLE
Refine pending sync workflow for pull throttling

### DIFF
--- a/IYSIntegration.API/Controllers/CommonController.cs
+++ b/IYSIntegration.API/Controllers/CommonController.cs
@@ -1,5 +1,6 @@
 ﻿using IYSIntegration.Application.Services;
 using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Error;
 using IYSIntegration.Application.Services.Models.Request.Consent;
@@ -7,6 +8,8 @@ using IYSIntegration.Application.Services.Models.Response.Consent;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Serilog;
+using System;
+using System.Collections.Generic;
 
 namespace IYSIntegration.API.Controllers
 {
@@ -17,12 +20,21 @@ namespace IYSIntegration.API.Controllers
         private readonly IDbService _dbService;
         private readonly IysProxy _client;
         private readonly IIysHelper _iysHelper;
+        private readonly IDuplicateCleanerService _duplicateCleanerService;
+        private readonly IPendingSyncService _pendingSyncService;
 
-        public CommonController(IDbService dbHelper, IysProxy iysClient, IIysHelper iysHelper)
+        public CommonController(
+            IDbService dbHelper,
+            IysProxy iysClient,
+            IIysHelper iysHelper,
+            IDuplicateCleanerService duplicateCleanerService,
+            IPendingSyncService pendingSyncService)
         {
             _dbService = dbHelper;
             _client = iysClient;
             _iysHelper = iysHelper;
+            _duplicateCleanerService = duplicateCleanerService;
+            _pendingSyncService = pendingSyncService;
         }
 
         [Route("addConsent")]
@@ -31,8 +43,7 @@ namespace IYSIntegration.API.Controllers
         {
             var response = new ResponseBase<AddConsentResult>();
 
-            if (string.IsNullOrEmpty(request.CompanyCode))
-                request.CompanyCode = _iysHelper.GetCompanyCode(request.IysCode);
+            request.CompanyCode = ResolveCompanyCode(request.CompanyCode, request.CompanyName, request.IysCode);
 
             if (string.IsNullOrWhiteSpace(request.Consent?.ConsentDate))
             {
@@ -40,48 +51,6 @@ namespace IYSIntegration.API.Controllers
             }
 
             DateTime.TryParse(request.Consent.ConsentDate, out var parsedDate);
-
-            var pullConsentExists = await _dbService.PullConsentExists(request.CompanyCode, request.Consent.Recipient);
-            if (!pullConsentExists)
-            {
-                var queryRequest = new QueryConsentRequest
-                {
-                    CompanyCode = request.CompanyCode,
-                    IysCode = request.IysCode,
-                    BrandCode = request.BrandCode,
-                    RecipientKey = new RecipientKey
-                    {
-                        Recipient = request.Consent.Recipient,
-                        RecipientType = request.Consent.RecipientType,
-                        Type = request.Consent.Type
-                    }
-                };
-
-                var queryResponse = await _client.PostJsonAsync<RecipientKey, QueryConsentResult>($"consents/{request.CompanyCode}/queryConsent", queryRequest.RecipientKey);
-                if (queryResponse.IsSuccessful() && queryResponse.Data != null && !string.IsNullOrEmpty(queryResponse.Data.ConsentDate))
-                {
-                    var pullInsertRequest = new AddConsentRequest
-                    {
-                        CompanyCode = request.CompanyCode,
-                        SalesforceId = request.SalesforceId,
-                        IysCode = request.IysCode,
-                        BrandCode = request.BrandCode,
-                        Consent = new Consent
-                        {
-                            Recipient = queryResponse.Data.Recipient,
-                            Type = queryResponse.Data.Type,
-                            Source = queryResponse.Data.Source,
-                            Status = queryResponse.Data.Status,
-                            ConsentDate = queryResponse.Data.ConsentDate,
-                            RecipientType = queryResponse.Data.RecipientType,
-                            CreationDate = queryResponse.Data.CreationDate,
-                            TransactionId = queryResponse.Data.TransactionId
-                        }
-                    };
-
-                    await _dbService.InsertPullConsent(pullInsertRequest);
-                }
-            }
 
             if (!await _dbService.CheckConsentRequest(request))
             {
@@ -111,6 +80,28 @@ namespace IYSIntegration.API.Controllers
                 response.Id = id;
                 await _dbService.UpdateConsentResponseFromCommon(response);
                 response.OriginalError = null;
+
+                if (id > 0 && request.Consent != null)
+                {
+                    var insertedConsent = new ConsentRequestLog
+                    {
+                        Id = id,
+                        CompanyCode = request.CompanyCode,
+                        IysCode = request.IysCode,
+                        BrandCode = request.BrandCode,
+                        Recipient = request.Consent.Recipient,
+                        RecipientType = request.Consent.RecipientType,
+                        Type = request.Consent.Type,
+                        Status = request.Consent.Status,
+                        Source = request.Consent.Source,
+                        ConsentDate = request.Consent.ConsentDate
+                    };
+
+                    var insertedConsents = new List<Consent> { insertedConsent };
+
+                    await _duplicateCleanerService.CleanAsync(insertedConsents);
+                    await _pendingSyncService.SyncAsync(insertedConsents);
+                }
             }
 
             return response;
@@ -120,10 +111,9 @@ namespace IYSIntegration.API.Controllers
         [HttpPost]
         public async Task<int> AddConsentAsync([FromBody] AddConsentRequest request)
         {
-            if (string.IsNullOrEmpty(request.CompanyCode))
-                request.CompanyCode = _iysHelper.GetCompanyCode(request.IysCode);
+            request.CompanyCode = ResolveCompanyCode(request.CompanyCode, request.CompanyName, request.IysCode);
 
-           return await _dbService.InsertConsentRequest(request);
+            return await _dbService.InsertConsentRequest(request);
         }
 
 
@@ -132,8 +122,7 @@ namespace IYSIntegration.API.Controllers
         [HttpPost]
         public async Task<ResponseBase<QueryConsentResult>> QueryConsent([FromBody] QueryConsentRequest request)
         {
-            if (string.IsNullOrEmpty(request.CompanyCode))
-                request.CompanyCode = _iysHelper.GetCompanyCode(request.IysCode);
+            request.CompanyCode = ResolveCompanyCode(request.CompanyCode, null, request.IysCode);
             return await _client.PostJsonAsync<RecipientKey, QueryConsentResult>($"consents/{request.CompanyCode}/queryConsent", request.RecipientKey);
         }
            
@@ -193,9 +182,9 @@ namespace IYSIntegration.API.Controllers
             var count = 0;
             var requestCount = request.Consents.Count;
             var response = new ResponseBase<MultipleConsentResult>();
+            var insertedConsents = new List<Consent>();
 
-            if (string.IsNullOrEmpty(request.CompanyCode))
-                request.CompanyCode = _iysHelper.GetCompanyCode(request.IysCode);
+            request.CompanyCode = ResolveCompanyCode(request.CompanyCode, request.CompanyName, request.IysCode);
 
             foreach (var consent in request.Consents)
             {
@@ -217,7 +206,32 @@ namespace IYSIntegration.API.Controllers
                 };
 
                 var result = await _dbService.InsertConsentRequest(addConsentRequest);
-                count += result;
+                if (result > 0)
+                {
+                    count++;
+                    if (addConsentRequest.Consent != null)
+                    {
+                        insertedConsents.Add(new ConsentRequestLog
+                        {
+                            Id = result,
+                            CompanyCode = addConsentRequest.CompanyCode,
+                            IysCode = addConsentRequest.IysCode,
+                            BrandCode = addConsentRequest.BrandCode,
+                            Recipient = addConsentRequest.Consent.Recipient,
+                            RecipientType = addConsentRequest.Consent.RecipientType,
+                            Type = addConsentRequest.Consent.Type,
+                            Status = addConsentRequest.Consent.Status,
+                            Source = addConsentRequest.Consent.Source,
+                            ConsentDate = addConsentRequest.Consent.ConsentDate
+                        });
+                    }
+                }
+            }
+
+            if (insertedConsents.Count > 0)
+            {
+                await _duplicateCleanerService.CleanAsync(insertedConsents);
+                await _pendingSyncService.SyncAsync(insertedConsents);
             }
 
             response.AddMessage("Success", $"{count}/{requestCount} kayıt başarı ile eklendi");
@@ -229,8 +243,7 @@ namespace IYSIntegration.API.Controllers
         [HttpPost]
         public async Task<ResponseBase<MultipleConsentResult>> SendMultipleConsent([FromBody] MultipleConsentRequest request)
         {
-            if (string.IsNullOrEmpty(request.CompanyCode))
-                request.CompanyCode = _iysHelper.GetCompanyCode(request.IysCode);
+            request.CompanyCode = ResolveCompanyCode(request.CompanyCode, request.CompanyName, request.IysCode);
 
             return await _client.PostJsonAsync<MultipleConsentRequest, MultipleConsentResult>($"consents/{request.CompanyCode}/sendMultipleConsent", request);
         }
@@ -241,8 +254,7 @@ namespace IYSIntegration.API.Controllers
         [HttpPost]
         public async Task<ResponseBase<List<QueryMultipleConsentResult>>> QueryMultipleConsent(QueryMultipleConsentRequest request)
         {
-            if (string.IsNullOrEmpty(request.CompanyCode))
-                request.CompanyCode = _iysHelper.GetCompanyCode(request.IysCode);
+            request.CompanyCode = ResolveCompanyCode(request.CompanyCode, null, request.IysCode);
 
             return await _client.PostJsonAsync<QueryMultipleConsentRequest, List<QueryMultipleConsentResult>>($"consents/{request.CompanyCode}/queryMultipleConsent", request);
         }
@@ -253,8 +265,7 @@ namespace IYSIntegration.API.Controllers
         [HttpPost]
         public async Task<ResponseBase<PullConsentResult>> PullConsent(PullConsentRequest request)
         {
-            if (string.IsNullOrEmpty(request.CompanyCode))
-                request.CompanyCode = _iysHelper.GetCompanyCode(request.IysCode);
+            request.CompanyCode = ResolveCompanyCode(request.CompanyCode, null, request.IysCode);
 
             return await _client.PostJsonAsync<PullConsentRequest, PullConsentResult>($"consents/{request.CompanyCode}/pullConsent", request);
         }
@@ -309,6 +320,23 @@ namespace IYSIntegration.API.Controllers
                     WsDescription = $"{errorResponse.FirstOrDefault().errorCode}-{errorResponse.FirstOrDefault().message}"
                 };
             }
+        }
+
+        private string? ResolveCompanyCode(string? companyCode, string? companyName, int iysCode)
+        {
+            if (!string.IsNullOrWhiteSpace(companyCode))
+            {
+                return companyCode.Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(companyName))
+            {
+                return companyName.Trim();
+            }
+
+            return iysCode != 0
+                ? _iysHelper.GetCompanyCode(iysCode)
+                : null;
         }
 
     }

--- a/IYSIntegration.API/Controllers/MaintenanceController.cs
+++ b/IYSIntegration.API/Controllers/MaintenanceController.cs
@@ -1,0 +1,52 @@
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models;
+using IYSIntegration.Application.Services.Models.Base;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class MaintenanceController : ControllerBase
+    {
+        private readonly IDuplicateCleanerService _duplicateCleanerService;
+        private readonly IPendingSyncService _pendingSyncService;
+        private readonly IOverdueOldConsentsService _overdueOldConsentsService;
+
+        public MaintenanceController(
+            IDuplicateCleanerService duplicateCleanerService,
+            IPendingSyncService pendingSyncService,
+            IOverdueOldConsentsService overdueOldConsentsService)
+        {
+            _duplicateCleanerService = duplicateCleanerService;
+            _pendingSyncService = pendingSyncService;
+            _overdueOldConsentsService = overdueOldConsentsService;
+        }
+
+        [HttpPost("clean-duplicates")]
+        public Task<ResponseBase<ScheduledJobStatistics>> CleanDuplicates()
+        {
+            return _duplicateCleanerService.RunBatchAsync();
+        }
+
+        [HttpPost("sync-pending")]
+        public Task<ResponseBase<ScheduledJobStatistics>> SyncPending([FromQuery] int rowCount = 900)
+        {
+            return _pendingSyncService.RunBatchAsync(rowCount);
+        }
+
+        [HttpPost("mark-overdue")]
+        public async Task<ResponseBase<int>> MarkOverdue()
+        {
+            var response = new ResponseBase<int>();
+            response.Success();
+
+            var count = await _overdueOldConsentsService.MarkOverdueAsync();
+            response.Data = count;
+            response.AddMessage("OverdueMarked", count.ToString());
+
+            return response;
+        }
+    }
+}

--- a/IYSIntegration.API/Controllers/ScheduledController.cs
+++ b/IYSIntegration.API/Controllers/ScheduledController.cs
@@ -1,4 +1,5 @@
-﻿using IYSIntegration.Application.Services;
+using IYSIntegration.Application.Services;
+using IYSIntegration.Application.Services.Interface;
 using Microsoft.AspNetCore.Mvc;
 
 namespace IYSIntegration.API.Controllers
@@ -13,13 +14,15 @@ namespace IYSIntegration.API.Controllers
         private readonly ScheduledPullConsentService _pullConsentService;
         private readonly ScheduledSfConsentService _sfConsentService;
         private readonly ScheduledSendConsentErrorService _sendConsentErrorService;
+        private readonly IPendingSyncService _pendingSyncService;
 
         public ScheduledController(ScheduledMultipleConsentQueryService multipleConsentQueryService,
                                    ScheduledSingleConsentAddService singleConsentAddService,
                                    ScheduledMultipleConsentAddService multipleConsentAddService,
                                    ScheduledPullConsentService pullConsentService,
                                    ScheduledSfConsentService sfConsentService,
-                                   ScheduledSendConsentErrorService sendConsentErrorService)
+                                   ScheduledSendConsentErrorService sendConsentErrorService,
+                                   IPendingSyncService pendingSyncService)
         {
             _multipleConsentQueryService = multipleConsentQueryService;
             _singleConsentAddService = singleConsentAddService;
@@ -27,6 +30,7 @@ namespace IYSIntegration.API.Controllers
             _pullConsentService = pullConsentService;
             _sfConsentService = sfConsentService;
             _sendConsentErrorService = sendConsentErrorService;
+            _pendingSyncService = pendingSyncService;
         }
 
         /// <summary>
@@ -75,6 +79,13 @@ namespace IYSIntegration.API.Controllers
         public async Task<IActionResult> PullConsent([FromQuery] int batchSize, bool resetAfter = false)
         {
             var result = await _pullConsentService.RunAsync(batchSize, resetAfter);
+            return StatusCode(result.IsSuccessful() ? 200 : 500, result);
+        }
+
+        [HttpGet("syncPendingConsents")]
+        public async Task<IActionResult> SyncPendingConsents([FromQuery] int batchSize = 900)
+        {
+            var result = await _pendingSyncService.RunBatchAsync(batchSize);
             return StatusCode(result.IsSuccessful() ? 200 : 500, result);
         }
         /// <summary>

--- a/IYSIntegration.API/Program.cs
+++ b/IYSIntegration.API/Program.cs
@@ -23,6 +23,11 @@ internal class Program
             var url = config.GetValue<string>("BaseIysProxyUrl");
             return new IysProxy(url);
         });
+        builder.Services.AddScoped<ScheduledDuplicateConsentCleanupService>();
+        builder.Services.AddScoped<ScheduledPendingConsentSyncService>();
+        builder.Services.AddScoped<IDuplicateCleanerService, DuplicateCleanerService>();
+        builder.Services.AddScoped<IPendingSyncService, PendingSyncService>();
+        builder.Services.AddScoped<IOverdueOldConsentsService, OverdueOldConsentsService>();
         builder.Services.AddScoped<ScheduledMultipleConsentQueryService>();
         builder.Services.AddScoped<ScheduledSingleConsentAddService>();
         builder.Services.AddScoped<ScheduledMultipleConsentAddService>();

--- a/IYSIntegration.Application/Services/DuplicateCleanerService.cs
+++ b/IYSIntegration.Application/Services/DuplicateCleanerService.cs
@@ -1,0 +1,58 @@
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models.Base;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.Application.Services
+{
+    public class DuplicateCleanerService : IDuplicateCleanerService
+    {
+        private readonly IDbService _dbService;
+        private readonly ScheduledDuplicateConsentCleanupService _scheduledCleanupService;
+        private readonly ILogger<DuplicateCleanerService> _logger;
+
+        public DuplicateCleanerService(
+            IDbService dbService,
+            ScheduledDuplicateConsentCleanupService scheduledCleanupService,
+            ILogger<DuplicateCleanerService> logger)
+        {
+            _dbService = dbService;
+            _scheduledCleanupService = scheduledCleanupService;
+            _logger = logger;
+        }
+
+        public async Task CleanAsync(IEnumerable<Consent> consents)
+        {
+            if (consents == null)
+            {
+                return;
+            }
+
+            var consentList = consents
+                .Where(c => c != null && !string.IsNullOrWhiteSpace(c.CompanyCode) && !string.IsNullOrWhiteSpace(c.Recipient))
+                .ToList();
+
+            if (consentList.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                await _dbService.MarkDuplicateConsentsOverdueForConsents(consentList);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "DuplicateCleanerService failed while marking duplicates.");
+            }
+        }
+
+        public Task<ResponseBase<ScheduledJobStatistics>> RunBatchAsync()
+        {
+            return _scheduledCleanupService.RunAsync();
+        }
+    }
+}

--- a/IYSIntegration.Application/Services/Interface/IDbService.cs
+++ b/IYSIntegration.Application/Services/Interface/IDbService.cs
@@ -43,5 +43,8 @@ namespace IYSIntegration.Application.Services.Interface
         Task<T> UpdateLogFromResponseBase<T>(ResponseBase<T> response, int id);
         Task<int> MarkConsentsOverdue(int maxAgeInDays);
         Task<int> MarkDuplicateConsentsOverdue();
+        Task<int> MarkDuplicateConsentsOverdueForConsents(IEnumerable<Consent> consents);
+        Task MarkConsentsAsNotPulled(IEnumerable<long> consentIds);
+        Task MarkConsentsAsPulled(IEnumerable<long> consentIds);
     }
 }

--- a/IYSIntegration.Application/Services/Interface/IDuplicateCleanerService.cs
+++ b/IYSIntegration.Application/Services/Interface/IDuplicateCleanerService.cs
@@ -1,0 +1,14 @@
+using IYSIntegration.Application.Services.Models;
+using IYSIntegration.Application.Services.Models.Base;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.Application.Services.Interface
+{
+    public interface IDuplicateCleanerService
+    {
+        Task CleanAsync(IEnumerable<Consent> consents);
+
+        Task<ResponseBase<ScheduledJobStatistics>> RunBatchAsync();
+    }
+}

--- a/IYSIntegration.Application/Services/Interface/IOverdueOldConsentsService.cs
+++ b/IYSIntegration.Application/Services/Interface/IOverdueOldConsentsService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace IYSIntegration.Application.Services.Interface
+{
+    public interface IOverdueOldConsentsService
+    {
+        Task<int> MarkOverdueAsync();
+    }
+}

--- a/IYSIntegration.Application/Services/Interface/IPendingSyncService.cs
+++ b/IYSIntegration.Application/Services/Interface/IPendingSyncService.cs
@@ -1,0 +1,14 @@
+using IYSIntegration.Application.Services.Models;
+using IYSIntegration.Application.Services.Models.Base;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.Application.Services.Interface
+{
+    public interface IPendingSyncService
+    {
+        Task SyncAsync(IEnumerable<Consent> consents);
+
+        Task<ResponseBase<ScheduledJobStatistics>> RunBatchAsync(int rowCount);
+    }
+}

--- a/IYSIntegration.Application/Services/Models/Request/Consent/AddConsentRequest.cs
+++ b/IYSIntegration.Application/Services/Models/Request/Consent/AddConsentRequest.cs
@@ -8,5 +8,6 @@ namespace IYSIntegration.Application.Services.Models.Request.Consent
         public bool WithoutLogging { get; set; }
         public string? SalesforceId { get; set; }
         public string? CompanyCode { get; set; }
+        public string? CompanyName { get; set; }
     }
 }

--- a/IYSIntegration.Application/Services/Models/Request/Consent/MultipleConsentRequest.cs
+++ b/IYSIntegration.Application/Services/Models/Request/Consent/MultipleConsentRequest.cs
@@ -4,7 +4,8 @@ namespace IYSIntegration.Application.Services.Models.Request.Consent
 {
     public class MultipleConsentRequest : ConsentParams
     {
-        public string CompanyCode { get; set; }
+        public string? CompanyCode { get; set; }
+        public string? CompanyName { get; set; }
         public int BatchId { get; set; }
         public bool ForBatch { get; set; }
         public List<Base.Consent> Consents { get; set; }

--- a/IYSIntegration.Application/Services/OverdueOldConsentsService.cs
+++ b/IYSIntegration.Application/Services/OverdueOldConsentsService.cs
@@ -1,0 +1,40 @@
+using IYSIntegration.Application.Services.Interface;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.Application.Services
+{
+    public class OverdueOldConsentsService : IOverdueOldConsentsService
+    {
+        private const int DefaultMaxAgeInDays = 3;
+
+        private readonly IDbService _dbService;
+        private readonly ILogger<OverdueOldConsentsService> _logger;
+
+        public OverdueOldConsentsService(IDbService dbService, ILogger<OverdueOldConsentsService> logger)
+        {
+            _dbService = dbService;
+            _logger = logger;
+        }
+
+        public async Task<int> MarkOverdueAsync()
+        {
+            try
+            {
+                var affected = await _dbService.MarkConsentsOverdue(DefaultMaxAgeInDays);
+                if (affected > 0)
+                {
+                    _logger.LogInformation("Marked {Count} consent records as overdue due to age.", affected);
+                }
+
+                return affected;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to mark overdue consents.");
+                return 0;
+            }
+        }
+    }
+}

--- a/IYSIntegration.Application/Services/PendingSyncService.cs
+++ b/IYSIntegration.Application/Services/PendingSyncService.cs
@@ -1,0 +1,202 @@
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models.Base;
+using IYSIntegration.Application.Services.Models.Request.Consent;
+using IYSIntegration.Application.Services.Models.Response.Consent;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.Application.Services
+{
+    public class PendingSyncService : IPendingSyncService
+    {
+        private readonly IDbService _dbService;
+        private readonly ScheduledPendingConsentSyncService _scheduledSyncService;
+        private readonly IysProxy _client;
+        private readonly IIysHelper _iysHelper;
+        private readonly ILogger<PendingSyncService> _logger;
+
+        public PendingSyncService(
+            IDbService dbService,
+            ScheduledPendingConsentSyncService scheduledSyncService,
+            IysProxy client,
+            IIysHelper iysHelper,
+            ILogger<PendingSyncService> logger)
+        {
+            _dbService = dbService;
+            _scheduledSyncService = scheduledSyncService;
+            _client = client;
+            _iysHelper = iysHelper;
+            _logger = logger;
+        }
+
+        public async Task SyncAsync(IEnumerable<Consent> consents)
+        {
+            if (consents == null)
+            {
+                return;
+            }
+
+            var consentLogs = consents
+                .Select(ToConsentRequestLog)
+                .Where(log => log != null && !string.IsNullOrWhiteSpace(log.Recipient))
+                .Cast<ConsentRequestLog>()
+                .ToList();
+
+            if (consentLogs.Count == 0)
+            {
+                return;
+            }
+
+            var processedRecipients = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var consentParamsCache = new Dictionary<string, ConsentParams>(StringComparer.OrdinalIgnoreCase);
+            var pullStatusCache = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            var markForDeferredSync = new List<long>();
+
+            foreach (var consentLog in consentLogs)
+            {
+                var companyCode = !string.IsNullOrWhiteSpace(consentLog.CompanyCode)
+                    ? consentLog.CompanyCode
+                    : _iysHelper.GetCompanyCode(consentLog.IysCode) ?? string.Empty;
+
+                if (string.IsNullOrWhiteSpace(companyCode))
+                {
+                    if (consentLog.Id > 0)
+                    {
+                        markForDeferredSync.Add(consentLog.Id);
+                    }
+
+                    continue;
+                }
+
+                var recipientType = consentLog.RecipientType ?? string.Empty;
+                var recipientKey = $"{companyCode}|{consentLog.Recipient}|{recipientType}";
+
+                if (!pullStatusCache.TryGetValue(recipientKey, out var hasPulled))
+                {
+                    hasPulled = await _dbService.PullConsentExists(companyCode, consentLog.Recipient);
+                    pullStatusCache[recipientKey] = hasPulled;
+                }
+
+                if (!hasPulled)
+                {
+                    if (consentLog.Id > 0)
+                    {
+                        markForDeferredSync.Add(consentLog.Id);
+                    }
+
+                    continue;
+                }
+
+                if (!processedRecipients.Add(recipientKey))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var queryRequest = new RecipientKey
+                    {
+                        Recipient = consentLog.Recipient,
+                        RecipientType = consentLog.RecipientType,
+                        Type = consentLog.Type
+                    };
+
+                    var queryResponse = await _client.PostJsonAsync<RecipientKey, QueryConsentResult>(
+                        $"consents/{companyCode}/queryConsent",
+                        queryRequest);
+
+                    if (queryResponse.IsSuccessful()
+                        && queryResponse.Data != null
+                        && !string.IsNullOrWhiteSpace(queryResponse.Data.ConsentDate))
+                    {
+                        if (!consentParamsCache.TryGetValue(companyCode, out var consentParams))
+                        {
+                            consentParams = consentLog.IysCode != 0 && consentLog.BrandCode != 0
+                                ? new ConsentParams { IysCode = consentLog.IysCode, BrandCode = consentLog.BrandCode }
+                                : _iysHelper.GetIysCode(companyCode);
+
+                            if (consentParams == null)
+                            {
+                                _logger.LogWarning(
+                                    "PendingSyncService could not resolve consent parameters for company {CompanyCode}.",
+                                    companyCode);
+                                continue;
+                            }
+
+                            consentParamsCache[companyCode] = consentParams;
+                        }
+
+                        var insertRequest = new AddConsentRequest
+                        {
+                            CompanyCode = companyCode,
+                            IysCode = consentParams.IysCode,
+                            BrandCode = consentParams.BrandCode,
+                            Consent = new Consent
+                            {
+                                Recipient = queryResponse.Data.Recipient,
+                                Type = queryResponse.Data.Type,
+                                Source = queryResponse.Data.Source,
+                                Status = queryResponse.Data.Status,
+                                ConsentDate = queryResponse.Data.ConsentDate,
+                                RecipientType = queryResponse.Data.RecipientType,
+                                CreationDate = queryResponse.Data.CreationDate,
+                                TransactionId = queryResponse.Data.TransactionId
+                            }
+                        };
+
+                        await _dbService.InsertPullConsent(insertRequest);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "PendingSyncService failed while syncing recipient {Recipient}", consentLog.Recipient);
+                }
+            }
+
+            if (markForDeferredSync.Count > 0)
+            {
+                try
+                {
+                    await _dbService.MarkConsentsAsNotPulled(markForDeferredSync);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "PendingSyncService failed while marking consents for deferred pull");
+                }
+            }
+        }
+
+        public Task<ResponseBase<ScheduledJobStatistics>> RunBatchAsync(int rowCount)
+        {
+            return _scheduledSyncService.RunAsync(rowCount);
+        }
+
+        private static ConsentRequestLog? ToConsentRequestLog(Consent consent)
+        {
+            if (consent is ConsentRequestLog requestLog)
+            {
+                return requestLog;
+            }
+
+            if (string.IsNullOrWhiteSpace(consent.CompanyCode))
+            {
+                return null;
+            }
+
+            return new ConsentRequestLog
+            {
+                CompanyCode = consent.CompanyCode,
+                Recipient = consent.Recipient,
+                RecipientType = consent.RecipientType,
+                Type = consent.Type,
+                Status = consent.Status,
+                Source = consent.Source,
+                ConsentDate = consent.ConsentDate,
+                Id = consent.Id
+            };
+        }
+    }
+}

--- a/IYSIntegration.Application/Services/ScheduledPendingConsentSyncService.cs
+++ b/IYSIntegration.Application/Services/ScheduledPendingConsentSyncService.cs
@@ -4,10 +4,13 @@ using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Request.Consent;
 using IYSIntegration.Application.Services.Models.Response.Consent;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace IYSIntegration.Application.Services
 {
@@ -36,14 +39,31 @@ namespace IYSIntegration.Application.Services
             response.Success();
 
             var results = new ConcurrentBag<LogResult>();
-            int successCount = 0;
-            int failedCount = 0;
+            var successCount = 0;
+            var failedCount = 0;
+
+            var limit = rowCount > 0 ? rowCount : 900;
+            var chunkSize = Math.Min(limit, 900);
+            if (chunkSize <= 0)
+            {
+                chunkSize = 900;
+            }
 
             try
             {
-                var pendingRequests = await _dbService.GetPendingConsentsWithoutPull(rowCount);
-                var processedRecipients = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                var consentParamsCache = new Dictionary<string, ConsentParams>(StringComparer.OrdinalIgnoreCase);
+                var pendingRequests = await _dbService.GetPendingConsentsWithoutPull(limit);
+
+                if (pendingRequests.Count == 0)
+                {
+                    response.Data = new ScheduledJobStatistics
+                    {
+                        SuccessCount = 0,
+                        FailedCount = 0
+                    };
+                    return response;
+                }
+
+                var requestsByCompany = new Dictionary<string, List<ConsentRequestLog>>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var request in pendingRequests)
                 {
@@ -66,85 +86,176 @@ namespace IYSIntegration.Application.Services
                         continue;
                     }
 
-                    var recipientKey = $"{companyCode}|{request.Recipient}|{request.RecipientType ?? string.Empty}";
-                    if (!processedRecipients.Add(recipientKey))
+                    if (!requestsByCompany.TryGetValue(companyCode, out var list))
+                    {
+                        list = new List<ConsentRequestLog>();
+                        requestsByCompany[companyCode] = list;
+                    }
+
+                    list.Add(request);
+                }
+
+                foreach (var kvp in requestsByCompany)
+                {
+                    var companyCode = kvp.Key;
+                    var requests = kvp.Value;
+
+                    if (requests.Count == 0)
                     {
                         continue;
                     }
 
-                    try
+                    var consentParams = ResolveConsentParams(companyCode, requests);
+                    if (consentParams == null)
                     {
-                        var queryRequest = new RecipientKey
-                        {
-                            Recipient = request.Recipient,
-                            RecipientType = request.RecipientType,
-                            Type = request.Type
-                        };
-
-                        var queryResponse = await _client.PostJsonAsync<RecipientKey, QueryConsentResult>(
-                            $"consents/{companyCode}/queryConsent",
-                            queryRequest);
-
-                        if (queryResponse.IsSuccessful()
-                            && queryResponse.Data != null
-                            && !string.IsNullOrWhiteSpace(queryResponse.Data.ConsentDate))
-                        {
-                            if (!consentParamsCache.TryGetValue(companyCode, out var consentParams))
-                            {
-                                consentParams = request.IysCode != 0 && request.BrandCode != 0
-                                    ? new ConsentParams { IysCode = request.IysCode, BrandCode = request.BrandCode }
-                                    : _iysHelper.GetIysCode(companyCode);
-                                consentParamsCache[companyCode] = consentParams;
-                            }
-
-                            var insertRequest = new AddConsentRequest
-                            {
-                                CompanyCode = companyCode,
-                                IysCode = consentParams.IysCode,
-                                BrandCode = consentParams.BrandCode,
-                                Consent = new Consent
-                                {
-                                    Recipient = queryResponse.Data.Recipient,
-                                    Type = queryResponse.Data.Type,
-                                    Source = queryResponse.Data.Source,
-                                    Status = queryResponse.Data.Status,
-                                    ConsentDate = queryResponse.Data.ConsentDate,
-                                    RecipientType = queryResponse.Data.RecipientType,
-                                    CreationDate = queryResponse.Data.CreationDate,
-                                    TransactionId = queryResponse.Data.TransactionId
-                                }
-                            };
-
-                            await _dbService.InsertPullConsent(insertRequest);
-                            Interlocked.Increment(ref successCount);
-                        }
-                        else
-                        {
-                            results.Add(new LogResult
-                            {
-                                Id = request.Id,
-                                CompanyCode = companyCode,
-                                Messages = new Dictionary<string, string>
-                                {
-                                    { "Query Error", BuildErrorMessage(queryResponse) }
-                                }
-                            });
-                            Interlocked.Increment(ref failedCount);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Pending consent sync error for recipient {Recipient}", request.Recipient);
                         results.Add(new LogResult
                         {
-                            Id = request.Id,
+                            Id = 0,
                             CompanyCode = companyCode,
                             Messages = new Dictionary<string, string>
                             {
-                                { "Exception", ex.Message }
+                                { "ConsentParams", "IYS kodu bulunamadı." }
                             }
                         });
-                        Interlocked.Increment(ref failedCount);
+                        Interlocked.Add(ref failedCount, requests.Count);
+                        continue;
+                    }
+
+                    for (var index = 0; index < requests.Count; index += chunkSize)
+                    {
+                        var length = Math.Min(chunkSize, requests.Count - index);
+                        var chunk = requests.GetRange(index, length);
+
+                        var payload = chunk
+                            .Select(r => new RecipientKey
+                            {
+                                Recipient = r.Recipient,
+                                RecipientType = r.RecipientType,
+                                Type = r.Type
+                            })
+                            .ToList();
+
+                        try
+                        {
+                            var queryResponse = await _client.PostJsonAsync<List<RecipientKey>, MultipleConsentResult>(
+                                $"consents/{companyCode}/queryMultipleConsent",
+                                payload);
+
+                            if (queryResponse.IsSuccessful()
+                                && queryResponse.Data?.SubRequests != null
+                                && queryResponse.Data.SubRequests.Length > 0)
+                            {
+                                var subRequests = queryResponse.Data.SubRequests;
+                                var processedIds = new List<long>();
+                                var maxLoop = Math.Min(subRequests.Length, chunk.Count);
+
+                                for (var i = 0; i < maxLoop; i++)
+                                {
+                                    var subRequest = subRequests[i];
+                                    var sourceConsent = chunk[i];
+
+                                    if (!string.Equals(subRequest.Status, "success", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        results.Add(new LogResult
+                                        {
+                                            Id = sourceConsent.Id,
+                                            CompanyCode = companyCode,
+                                            Messages = new Dictionary<string, string>
+                                            {
+                                                { "QueryMultipleConsent", subRequest.Status ?? "Bilinmeyen durum" }
+                                            }
+                                        });
+                                        Interlocked.Increment(ref failedCount);
+                                        continue;
+                                    }
+
+                                    var insertRequest = new AddConsentRequest
+                                    {
+                                        CompanyCode = companyCode,
+                                        IysCode = consentParams.IysCode,
+                                        BrandCode = consentParams.BrandCode,
+                                        Consent = new Consent
+                                        {
+                                            Recipient = subRequest.Recipient ?? sourceConsent.Recipient,
+                                            Type = subRequest.Type ?? sourceConsent.Type,
+                                            Source = subRequest.Source ?? sourceConsent.Source,
+                                            Status = subRequest.Status,
+                                            ConsentDate = subRequest.ConsentDate.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture),
+                                            RecipientType = subRequest.RecipientType ?? sourceConsent.RecipientType,
+                                            TransactionId = subRequest.SubRequestId
+                                        }
+                                    };
+
+                                    await _dbService.InsertPullConsent(insertRequest);
+                                    processedIds.Add(sourceConsent.Id);
+                                    Interlocked.Increment(ref successCount);
+                                }
+
+                                if (chunk.Count > maxLoop)
+                                {
+                                    for (var i = maxLoop; i < chunk.Count; i++)
+                                    {
+                                        var missing = chunk[i];
+                                        results.Add(new LogResult
+                                        {
+                                            Id = missing.Id,
+                                            CompanyCode = companyCode,
+                                            Messages = new Dictionary<string, string>
+                                            {
+                                                { "QueryMultipleConsent", "Yanıt alınamadı." }
+                                            }
+                                        });
+                                        Interlocked.Increment(ref failedCount);
+                                    }
+                                }
+
+                                if (processedIds.Count > 0)
+                                {
+                                    try
+                                    {
+                                        await _dbService.MarkConsentsAsPulled(processedIds);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        _logger.LogError(ex, "Failed to update IsPulled flags for company {CompanyCode}", companyCode);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                var errorMessage = BuildErrorMessage(queryResponse);
+                                foreach (var request in chunk)
+                                {
+                                    results.Add(new LogResult
+                                    {
+                                        Id = request.Id,
+                                        CompanyCode = companyCode,
+                                        Messages = new Dictionary<string, string>
+                                        {
+                                            { "QueryMultipleConsent", errorMessage }
+                                        }
+                                    });
+                                    Interlocked.Increment(ref failedCount);
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Pending consent multi query error for company {CompanyCode}", companyCode);
+                            foreach (var request in chunk)
+                            {
+                                results.Add(new LogResult
+                                {
+                                    Id = request.Id,
+                                    CompanyCode = companyCode,
+                                    Messages = new Dictionary<string, string>
+                                    {
+                                        { "Exception", ex.Message }
+                                    }
+                                });
+                                Interlocked.Increment(ref failedCount);
+                            }
+                        }
                     }
                 }
             }
@@ -175,6 +286,21 @@ namespace IYSIntegration.Application.Services
             };
 
             return response;
+        }
+
+        private ConsentParams? ResolveConsentParams(string companyCode, List<ConsentRequestLog> requests)
+        {
+            var withCodes = requests.FirstOrDefault(r => r.IysCode != 0 && r.BrandCode != 0);
+            if (withCodes != null)
+            {
+                return new ConsentParams
+                {
+                    IysCode = withCodes.IysCode,
+                    BrandCode = withCodes.BrandCode
+                };
+            }
+
+            return _iysHelper.GetIysCode(companyCode);
         }
 
         private static string BuildErrorMessage<T>(ResponseBase<T> response)


### PR DESCRIPTION
## Summary
- remove the controller-level single consent query so throttling is enforced by the pending sync pipeline
- add database helpers and PendingSyncService logic to flag newly logged requests with IsPulled = 0 when no historical pull data exists
- extend the scheduled pending sync job to batch-query IsPulled = 0 records in 900 item chunks, mark successful rows as pulled, and expose the job via scheduled and maintenance endpoints

## Testing
- dotnet build IYSIntegration.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbb5007808322ab0eed09e64fd91a