### PR TITLE
Fix service return type references for scheduled job statistics

### DIFF
--- a/IYSIntegration.Application/Services/DuplicateCleanerService.cs
+++ b/IYSIntegration.Application/Services/DuplicateCleanerService.cs
@@ -1,4 +1,5 @@
 using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models;
 using IYSIntegration.Application.Services.Models.Base;
 using Microsoft.Extensions.Logging;
 using System;

--- a/IYSIntegration.Application/Services/PendingSyncService.cs
+++ b/IYSIntegration.Application/Services/PendingSyncService.cs
@@ -1,4 +1,5 @@
 using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Request.Consent;
 using IYSIntegration.Application.Services.Models.Response.Consent;


### PR DESCRIPTION
## Summary
- add the models namespace so DuplicateCleanerService and PendingSyncService can return ScheduledJobStatistics as required by their interfaces

## Testing
- `dotnet build` *(fails: `dotnet` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe0a192608322b1c2f0d0a030c8b7