### PR TITLE
Mark missing consent responses as pulled

### DIFF
--- a/IYSIntegration.Application/Services/Constants/QueryStrings.cs
+++ b/IYSIntegration.Application/Services/Constants/QueryStrings.cs
@@ -270,6 +270,7 @@
             WHERE
                                 ISNULL(IsProcessed, 0) = @IsProcessed
                                 AND IsOverdue IS NULL
+                                AND ISNULL(IsPulled, 0) = 1
             ORDER BY
                                 Id DESC;
            ";

--- a/IYSIntegration.Application/Services/ScheduledPendingConsentSyncService.cs
+++ b/IYSIntegration.Application/Services/ScheduledPendingConsentSyncService.cs
@@ -146,7 +146,7 @@ namespace IYSIntegration.Application.Services
                                 && queryResponse.Data.SubRequests.Length > 0)
                             {
                                 var subRequests = queryResponse.Data.SubRequests;
-                                var processedIds = new List<long>();
+                                var consentIdsToMarkPulled = new List<long>();
                                 var maxLoop = Math.Min(subRequests.Length, chunk.Count);
 
                                 for (var i = 0; i < maxLoop; i++)
@@ -187,7 +187,7 @@ namespace IYSIntegration.Application.Services
                                     };
 
                                     await _dbService.InsertPullConsent(insertRequest);
-                                    processedIds.Add(sourceConsent.Id);
+                                    consentIdsToMarkPulled.Add(sourceConsent.Id);
                                     Interlocked.Increment(ref successCount);
                                 }
 
@@ -206,14 +206,15 @@ namespace IYSIntegration.Application.Services
                                             }
                                         });
                                         Interlocked.Increment(ref failedCount);
+                                        consentIdsToMarkPulled.Add(missing.Id);
                                     }
                                 }
 
-                                if (processedIds.Count > 0)
+                                if (consentIdsToMarkPulled.Count > 0)
                                 {
                                     try
                                     {
-                                        await _dbService.MarkConsentsAsPulled(processedIds);
+                                        await _dbService.MarkConsentsAsPulled(consentIdsToMarkPulled);
                                     }
                                     catch (Exception ex)
                                     {


### PR DESCRIPTION
## Summary
- ensure consents without responses from bulk IYS queries are still marked as pulled
- require IsPulled flag when selecting consents to send to IYS

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe3eeb1bc83229362041328508639