### PR TITLE
Improve consent existence batching

### DIFF
--- a/IYSIntegration.Application/Services/CheckConsentEntityService.cs
+++ b/IYSIntegration.Application/Services/CheckConsentEntityService.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models;
+using IYSIntegration.Application.Services.Models.Base;
+using Microsoft.Extensions.Logging;
+
+namespace IYSIntegration.Application.Services
+{
+    public class CheckConsentEntityService
+    {
+        private readonly IDbService _dbService;
+        private readonly ILogger<CheckConsentEntityService> _logger;
+
+        public CheckConsentEntityService(IDbService dbService, ILogger<CheckConsentEntityService> logger)
+        {
+            _dbService = dbService;
+            _logger = logger;
+        }
+
+        public async Task<bool> HasExistingConsentAsync(Consent consent)
+        {
+            if (consent == null)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(consent.CompanyCode) || string.IsNullOrWhiteSpace(consent.Recipient))
+            {
+                _logger.LogWarning("Consent is missing required fields: CompanyCode='{CompanyCode}', Recipient='{Recipient}'", consent.CompanyCode, consent.Recipient);
+                return false;
+            }
+
+            try
+            {
+                var type = string.IsNullOrWhiteSpace(consent.Type) ? null : consent.Type;
+
+                if (await _dbService.PullConsentExists(consent.CompanyCode!, consent.Recipient!, type))
+                {
+                    return true;
+                }
+
+                return await _dbService.SuccessfulConsentRequestExists(consent.CompanyCode!, consent.Recipient!, type);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to check consent existence for CompanyCode='{CompanyCode}', Recipient='{Recipient}'", consent.CompanyCode, consent.Recipient);
+                return false;
+            }
+        }
+
+        public async Task<ConsentExistenceResult> HasExistingConsentAsync(IEnumerable<Consent> consents)
+        {
+            var result = new ConsentExistenceResult();
+
+            if (consents == null)
+            {
+                return result;
+            }
+
+            var validConsents = consents
+                .Where(c => c != null)
+                .ToList();
+
+            var missingCompanyConsents = validConsents
+                .Where(c => string.IsNullOrWhiteSpace(c.CompanyCode))
+                .ToList();
+
+            foreach (var consent in missingCompanyConsents)
+            {
+                _logger.LogWarning("Consent is missing required company code.");
+                result.NonConsents.Add(consent);
+            }
+
+            var groupedConsents = validConsents
+                .Where(c => !string.IsNullOrWhiteSpace(c.CompanyCode))
+                .GroupBy(c => new
+                {
+                    CompanyCode = c!.CompanyCode!.Trim(),
+                    Type = string.IsNullOrWhiteSpace(c?.Type) ? null : c!.Type!.Trim()
+                });
+
+            foreach (var group in groupedConsents)
+            {
+                var companyCode = group.Key.CompanyCode;
+                var type = group.Key.Type;
+                var recipients = group
+                    .Where(c => !string.IsNullOrWhiteSpace(c.Recipient))
+                    .Select(c => c.Recipient!.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                if (!recipients.Any())
+                {
+                    foreach (var consent in group)
+                    {
+                        _logger.LogWarning("Consent is missing required recipient for CompanyCode='{CompanyCode}'", companyCode);
+                        result.NonConsents.Add(consent);
+                    }
+
+                    continue;
+                }
+
+                List<string> existingRecipients;
+
+                try
+                {
+                    existingRecipients = await _dbService.GetExistingConsentRecipients(companyCode, type, recipients);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to fetch existing consents for CompanyCode='{CompanyCode}', Type='{Type}'", companyCode, type);
+
+                    foreach (var consent in group)
+                    {
+                        result.NonConsents.Add(consent);
+                    }
+
+                    continue;
+                }
+
+                var existingRecipientSet = new HashSet<string>(
+                    (existingRecipients ?? new List<string>())
+                        .Where(r => !string.IsNullOrWhiteSpace(r))
+                        .Select(r => r.Trim()),
+                    StringComparer.OrdinalIgnoreCase);
+
+                foreach (var consent in group)
+                {
+                    if (string.IsNullOrWhiteSpace(consent.Recipient))
+                    {
+                        _logger.LogWarning("Consent is missing required recipient for CompanyCode='{CompanyCode}'", companyCode);
+                        result.NonConsents.Add(consent);
+                        continue;
+                    }
+
+                    var recipient = consent.Recipient!.Trim();
+
+                    if (existingRecipientSet.Contains(recipient))
+                    {
+                        result.ExistConsents.Add(consent);
+                    }
+                    else
+                    {
+                        result.NonConsents.Add(consent);
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/IYSIntegration.Application/Services/Constants/QueryStrings.cs
+++ b/IYSIntegration.Application/Services/Constants/QueryStrings.cs
@@ -200,6 +200,26 @@
                   AND (BatchError IS NULL OR LTRIM(RTRIM(BatchError)) = '')
             ) THEN 1 ELSE 0 END;";
 
+        public static string GetExistingConsentRecipients = @"
+            SELECT DISTINCT Recipient
+            FROM (
+                SELECT Recipient
+                FROM SfdcMasterData.dbo.IysPullConsent (NOLOCK)
+                WHERE CompanyCode = @CompanyCode
+                  AND Recipient IN @Recipients
+                  AND (@Type IS NULL OR @Type = '' OR ISNULL(Type, '') = ISNULL(@Type, ''))
+                UNION ALL
+                SELECT Recipient
+                FROM SfdcMasterData.dbo.IYSConsentRequest (NOLOCK)
+                WHERE CompanyCode = @CompanyCode
+                  AND Recipient IN @Recipients
+                  AND (@Type IS NULL OR @Type = '' OR ISNULL(Type, '') = ISNULL(@Type, ''))
+                  AND ISNULL(IsProcessed, 0) = 1
+                  AND ISNULL(IsSuccess, 0) = 1
+                  AND ISNULL(IsOverdue, 0) = 0
+                  AND (BatchError IS NULL OR LTRIM(RTRIM(BatchError)) = '')
+            ) Existing;";
+
         public static string GetLastConsents = @"
             WITH FilteredConsents AS (
                 SELECT CompanyCode, Recipient, RecipientType, Status, ConsentDate

--- a/IYSIntegration.Application/Services/DbService.cs
+++ b/IYSIntegration.Application/Services/DbService.cs
@@ -215,6 +215,27 @@ namespace IYSIntegration.Application.Services
             }
         }
 
+        public async Task<List<string>> GetExistingConsentRecipients(string companyCode, string? type, IEnumerable<string> recipients)
+        {
+            using (var connection = new SqlConnection(_configuration.GetValue<string>("ConnectionStrings:SfdcMasterData")))
+            {
+                await connection.OpenAsync();
+
+                var result = (await connection.QueryAsync<string>(
+                    QueryStrings.GetExistingConsentRecipients,
+                    new
+                    {
+                        CompanyCode = companyCode,
+                        Type = string.IsNullOrWhiteSpace(type) ? null : type.Trim(),
+                        Recipients = recipients
+                    })).ToList();
+
+                await connection.CloseAsync();
+
+                return result;
+            }
+        }
+
         public async Task<DateTime?> GetLastConsentDate(string companyCode, string recipient)
         {
             using (var connection = new SqlConnection(_configuration.GetValue<string>("ConnectionStrings:SfdcMasterData")))

--- a/IYSIntegration.Application/Services/Interface/IDbService.cs
+++ b/IYSIntegration.Application/Services/Interface/IDbService.cs
@@ -15,6 +15,7 @@ namespace IYSIntegration.Application.Services.Interface
         Task<bool> CheckConsentRequest(AddConsentRequest request);
         Task<bool> PullConsentExists(string companyCode, string recipient, string? type = null);
         Task<bool> SuccessfulConsentRequestExists(string companyCode, string recipient, string? type = null);
+        Task<List<string>> GetExistingConsentRecipients(string companyCode, string? type, IEnumerable<string> recipients);
         Task<DateTime?> GetLastConsentDate(string companyCode, string recipient);
         Task<List<Consent>> GetLastConsents(string companyCode, IEnumerable<string> recipients);
         Task UpdateConsentResponseFromCommon(ResponseBase<AddConsentResult> response);

--- a/IYSIntegration.Application/Services/Models/ConsentExistenceResult.cs
+++ b/IYSIntegration.Application/Services/Models/ConsentExistenceResult.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using IYSIntegration.Application.Services.Models.Base;
+
+namespace IYSIntegration.Application.Services.Models
+{
+    public class ConsentExistenceResult
+    {
+        public List<Consent> ExistConsents { get; } = new List<Consent>();
+
+        public List<Consent> NonConsents { get; } = new List<Consent>();
+    }
+}


### PR DESCRIPTION
## Summary
- add a result model to return existing and missing consent collections
- batch consent existence checks by grouping per company and type with normalized recipients
- query existing recipients in bulk through a new database helper and SQL union

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1149db708322a7a5f3f8580b5e93