### PR TITLE
Add SyncConsentService for updating consent statuses

### DIFF
--- a/IYSIntegration.API/Program.cs
+++ b/IYSIntegration.API/Program.cs
@@ -27,6 +27,7 @@ internal class Program
         builder.Services.AddScoped<ScheduledPendingConsentSyncService>();
         builder.Services.AddScoped<IDuplicateCleanerService, DuplicateCleanerService>();
         builder.Services.AddScoped<IPendingSyncService, PendingSyncService>();
+        builder.Services.AddScoped<ISyncConsentService, SyncConsentService>();
         builder.Services.AddScoped<IOverdueOldConsentsService, OverdueOldConsentsService>();
         builder.Services.AddScoped<ScheduledMultipleConsentQueryService>();
         builder.Services.AddScoped<ScheduledSingleConsentAddService>();

--- a/IYSIntegration.Application/Services/Constants/QueryStrings.cs
+++ b/IYSIntegration.Application/Services/Constants/QueryStrings.cs
@@ -578,35 +578,45 @@
 		";
 
         public static string GetPullConsentRequests = @"
-            SELECT TOP {0} 
-				Id, 
-				CompanyCode, 
-				SalesforceId, 
-				IysCode, 
-				BrandCode, 
-				convert(varchar, ConsentDate, 120) as ConsentDate, 
-				convert(varchar, CreationDate, 120) as CreationDate, 
-				[Source], 
-				Recipient, 
-				RecipientType, 
-				Status, 
-				[Type], 
-				TransactionId, 
-				IsSuccess, 
-				CreateDate, 
-				UpdateDate, 
-				LogId, 
-				IsProcessed, 
-				Error
-			FROM dbo.IysPullConsent (nolock)
+            SELECT TOP {0}
+                                Id,
+                                CompanyCode,
+                                SalesforceId,
+                                IysCode,
+                                BrandCode,
+                                convert(varchar, ConsentDate, 120) as ConsentDate,
+                                convert(varchar, CreationDate, 120) as CreationDate,
+                                [Source],
+                                Recipient,
+                                RecipientType,
+                                Status,
+                                [Type],
+                                TransactionId,
+                                IsSuccess,
+                                CreateDate,
+                                UpdateDate,
+                                LogId,
+                                IsProcessed,
+                                Error
+                        FROM dbo.IysPullConsent (nolock)
                 WHERE ISNULL(IsProcessed, 0) = @IsProcessed
                 ORDER BY CreateDate ASC;
-		";
+                ";
+
+        public static string UpdatePullConsentStatuses = @"
+            UPDATE dbo.IysPullConsent
+            SET Status = @Status,
+                UpdateDate = GETDATE()
+            WHERE CompanyCode = @CompanyCode
+              AND RecipientType = @RecipientType
+              AND [Type] = @Type
+              AND Recipient IN @Recipients;
+            ";
 
         public static string UpdateSfConsentRequest = @"
             UPDATE dbo.IysPullConsent
             SET IsSuccess = @IsSuccess,
-                LogId = @LogId,    
+                LogId = @LogId,
                 UpdateDate = GETDATE(),
 				Error = @Error,
                 IsProcessed = 1

--- a/IYSIntegration.Application/Services/Interface/IDbService.cs
+++ b/IYSIntegration.Application/Services/Interface/IDbService.cs
@@ -40,6 +40,7 @@ namespace IYSIntegration.Application.Services.Interface
         Task UpdateJustRequestDateOfPullRequestLog(PullRequestLog log);
         Task InsertPullConsent(AddConsentRequest request);
         Task<List<Consent>> GetPullConsentRequests(bool isProcessed, int rowCount);
+        Task UpdatePullConsentStatuses(string companyCode, string recipientType, string type, IEnumerable<string> recipients, string status);
         Task UpdateSfConsentResponse(SfConsentResult consentResult);
         Task<List<Consent>> GetIYSConsentRequestErrors(DateTime? date = null);
         Task<T> UpdateLogFromResponseBase<T>(ResponseBase<T> response, int id);

--- a/IYSIntegration.Application/Services/Interface/ISyncConsentService.cs
+++ b/IYSIntegration.Application/Services/Interface/ISyncConsentService.cs
@@ -1,0 +1,12 @@
+using IYSIntegration.Application.Services.Models.Base;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.Application.Services.Interface
+{
+    public interface ISyncConsentService
+    {
+        Task<IReadOnlyCollection<Consent>> SyncAsync(IEnumerable<Consent> consents, CancellationToken cancellationToken = default);
+    }
+}

--- a/IYSIntegration.Application/Services/SyncConsentService.cs
+++ b/IYSIntegration.Application/Services/SyncConsentService.cs
@@ -1,0 +1,173 @@
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models.Base;
+using IYSIntegration.Application.Services.Models.Response.Consent;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IYSIntegration.Application.Services
+{
+    public class SyncConsentService : ISyncConsentService
+    {
+        private readonly IDbService _dbService;
+        private readonly IysProxy _client;
+        private readonly ILogger<SyncConsentService> _logger;
+
+        public SyncConsentService(IDbService dbService, IysProxy client, ILogger<SyncConsentService> logger)
+        {
+            _dbService = dbService;
+            _client = client;
+            _logger = logger;
+        }
+
+        public async Task<IReadOnlyCollection<Consent>> SyncAsync(IEnumerable<Consent> consents, CancellationToken cancellationToken = default)
+        {
+            if (consents == null)
+            {
+                return Array.Empty<Consent>();
+            }
+
+            var preparedConsents = consents
+                .Where(consent => consent != null)
+                .Select(consent => new ConsentGroupItem(
+                    consent,
+                    consent.CompanyCode?.Trim() ?? string.Empty,
+                    consent.Recipient?.Trim() ?? string.Empty,
+                    consent.RecipientType?.Trim() ?? string.Empty,
+                    consent.Type?.Trim() ?? string.Empty))
+                .Where(item => !string.IsNullOrWhiteSpace(item.CompanyCode)
+                               && !string.IsNullOrWhiteSpace(item.Recipient)
+                               && !string.IsNullOrWhiteSpace(item.RecipientType)
+                               && !string.IsNullOrWhiteSpace(item.Type))
+                .ToList();
+
+            if (preparedConsents.Count == 0)
+            {
+                return Array.Empty<Consent>();
+            }
+
+            var approvedConsents = new List<Consent>();
+
+            foreach (var group in preparedConsents.GroupBy(
+                         item => (item.CompanyCode, item.RecipientType, item.Type),
+                         ConsentGroupComparer.Instance))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var recipients = group
+                    .Select(item => item.Recipient)
+                    .Where(recipient => !string.IsNullOrWhiteSpace(recipient))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                if (recipients.Count == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var request = new RecipientKeyWithList
+                    {
+                        RecipientType = group.Key.RecipientType,
+                        Type = group.Key.Type,
+                        Recipients = recipients
+                    };
+
+                    var response = await _client.PostJsonAsync<RecipientKeyWithList, MultipleQueryConsentResult>(
+                        $"consents/{group.Key.CompanyCode}/queryMultipleConsent",
+                        request,
+                        cancellationToken);
+
+                    if (!response.IsSuccessful())
+                    {
+                        _logger.LogWarning(
+                            "SyncConsentService query failed for company {CompanyCode}, recipientType {RecipientType}, type {Type}.",
+                            group.Key.CompanyCode,
+                            group.Key.RecipientType,
+                            group.Key.Type);
+                        continue;
+                    }
+
+                    var approvedRecipients = response.Data?.List?.Count > 0
+                        ? response.Data.List
+                            .Where(recipient => !string.IsNullOrWhiteSpace(recipient))
+                            .Select(recipient => recipient.Trim())
+                            .ToHashSet(StringComparer.OrdinalIgnoreCase)
+                        : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                    var rejectedRecipients = recipients
+                        .Where(recipient => approvedRecipients.Count == 0 || !approvedRecipients.Contains(recipient))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+
+                    if (rejectedRecipients.Count > 0)
+                    {
+                        await _dbService.UpdatePullConsentStatuses(
+                            group.Key.CompanyCode,
+                            group.Key.RecipientType,
+                            group.Key.Type,
+                            rejectedRecipients,
+                            "RET");
+                    }
+
+                    if (approvedRecipients.Count > 0)
+                    {
+                        await _dbService.UpdatePullConsentStatuses(
+                            group.Key.CompanyCode,
+                            group.Key.RecipientType,
+                            group.Key.Type,
+                            approvedRecipients,
+                            "ONAY");
+
+                        approvedConsents.AddRange(group
+                            .Where(item => approvedRecipients.Contains(item.Recipient))
+                            .Select(item => item.Consent));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "SyncConsentService failed for company {CompanyCode}, recipientType {RecipientType}, type {Type}.",
+                        group.Key.CompanyCode,
+                        group.Key.RecipientType,
+                        group.Key.Type);
+                }
+            }
+
+            return approvedConsents;
+        }
+
+        private sealed record ConsentGroupItem(
+            Consent Consent,
+            string CompanyCode,
+            string Recipient,
+            string RecipientType,
+            string Type);
+
+        private sealed class ConsentGroupComparer : IEqualityComparer<(string CompanyCode, string RecipientType, string Type)>
+        {
+            public static readonly ConsentGroupComparer Instance = new();
+
+            public bool Equals((string CompanyCode, string RecipientType, string Type) x, (string CompanyCode, string RecipientType, string Type) y)
+            {
+                return string.Equals(x.CompanyCode, y.CompanyCode, StringComparison.OrdinalIgnoreCase)
+                       && string.Equals(x.RecipientType, y.RecipientType, StringComparison.OrdinalIgnoreCase)
+                       && string.Equals(x.Type, y.Type, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public int GetHashCode((string CompanyCode, string RecipientType, string Type) obj)
+            {
+                var hash = new HashCode();
+                hash.Add(obj.CompanyCode, StringComparer.OrdinalIgnoreCase);
+                hash.Add(obj.RecipientType, StringComparer.OrdinalIgnoreCase);
+                hash.Add(obj.Type, StringComparer.OrdinalIgnoreCase);
+                return hash.ToHashCode();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a SyncConsentService that groups consents by company and recipient metadata, queries the proxy’s queryMultipleConsent endpoint, and updates database statuses for returned and missing recipients
- extend the database service and SQL constants with support for bulk pull consent status updates and register the new service for DI

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1c11d6488322bbb86a9562286fc8