### PR TITLE
Add single consent sync helper

### DIFF
--- a/IYSIntegration.Application/Services/Interface/ISyncConsentService.cs
+++ b/IYSIntegration.Application/Services/Interface/ISyncConsentService.cs
@@ -7,6 +7,7 @@ namespace IYSIntegration.Application.Services.Interface
 {
     public interface ISyncConsentService
     {
+        Task<Consent?> SyncAsync(Consent consent, CancellationToken cancellationToken = default);
         Task<IReadOnlyCollection<Consent>> SyncAsync(IEnumerable<Consent> consents, CancellationToken cancellationToken = default);
     }
 }

--- a/IYSIntegration.Application/Services/SyncConsentService.cs
+++ b/IYSIntegration.Application/Services/SyncConsentService.cs
@@ -23,6 +23,17 @@ namespace IYSIntegration.Application.Services
             _logger = logger;
         }
 
+        public async Task<Consent?> SyncAsync(Consent consent, CancellationToken cancellationToken = default)
+        {
+            if (consent == null)
+            {
+                return null;
+            }
+
+            var syncedConsents = await SyncAsync(new[] { consent }, cancellationToken);
+            return syncedConsents.FirstOrDefault();
+        }
+
         public async Task<IReadOnlyCollection<Consent>> SyncAsync(IEnumerable<Consent> consents, CancellationToken cancellationToken = default)
         {
             if (consents == null)


### PR DESCRIPTION
## Summary
- add an overload to `ISyncConsentService` that works with a single consent
- implement the single-consent sync flow in `SyncConsentService` by delegating to the batch logic

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4bda756c8322a135e6fc71b5f146