### PR TITLE
Always queue consent requests before forcing send

### DIFF
--- a/IYSIntegration.Application/Services/Interface/IIysHelper.cs
+++ b/IYSIntegration.Application/Services/Interface/IIysHelper.cs
@@ -31,4 +31,6 @@ public interface IIysHelper
         bool runPendingSync = true);
 
     string? ResolveCompanyCode(string? companyCode, string? companyName, int iysCode);
+
+    string BuildAddConsentErrorMessage(ResponseBase<AddConsentResult> addResponse);
 }

--- a/IYSIntegration.Application/Services/Models/Request/Consent/AddConsentRequest.cs
+++ b/IYSIntegration.Application/Services/Models/Request/Consent/AddConsentRequest.cs
@@ -5,7 +5,7 @@ namespace IYSIntegration.Application.Services.Models.Request.Consent
     public class AddConsentRequest : ConsentParams
     {
         public Base.Consent Consent { get; set; }
-        public bool WithoutLogging { get; set; }
+        public bool ForceSend { get; set; }
         public string? SalesforceId { get; set; }
         public string? CompanyCode { get; set; }
         public string? CompanyName { get; set; }

--- a/IYSIntegration.Application/Services/Models/Request/Consent/MultipleConsentRequest.cs
+++ b/IYSIntegration.Application/Services/Models/Request/Consent/MultipleConsentRequest.cs
@@ -8,6 +8,7 @@ namespace IYSIntegration.Application.Services.Models.Request.Consent
         public string? CompanyName { get; set; }
         public int BatchId { get; set; }
         public bool ForBatch { get; set; }
+        public bool ForceSend { get; set; }
         public List<Base.Consent> Consents { get; set; }
 
     }

--- a/IYSIntegration.Application/Services/ScheduledSingleConsentAddService.cs
+++ b/IYSIntegration.Application/Services/ScheduledSingleConsentAddService.cs
@@ -75,7 +75,7 @@ public class ScheduledSingleConsentAddService
                 {
                     var request = new AddConsentRequest
                     {
-                        WithoutLogging = true,
+                        ForceSend = true,
                         IysCode = log.IysCode,
                         BrandCode = log.BrandCode,
                         CompanyCode = companyCode,


### PR DESCRIPTION
## Summary
- ensure single-consent submissions always enqueue before optionally forcing the send and persist the send outcome
- make bulk submissions queue each consent prior to optional force-sending and reuse the helper error formatter
- expose the consent error message builder on the helper so controllers no longer duplicate that logic

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc54d6f47c8322869f906480873e7f