### PR TITLE
Parse batch errors and add error report stats endpoint

### DIFF
--- a/IYSIntegration.API/Controllers/CommonController.cs
+++ b/IYSIntegration.API/Controllers/CommonController.cs
@@ -366,5 +366,12 @@ namespace IYSIntegration.API.Controllers
             return StatusCode(result.IsSuccessful() ? 200 : 500, result);
         }
 
+        [HttpGet("GetErrorReportStats")]
+        public async Task<IActionResult> GetConsentErrorStats([FromQuery] DateTime? date)
+        {
+            var result = await _sendConsentErrorService.GetErrorReportStatsAsync(date);
+            return StatusCode(result.IsSuccessful() ? 200 : 500, result);
+        }
+
     }
 }

--- a/IYSIntegration.Application/Services/Models/Base/Consent.cs
+++ b/IYSIntegration.Application/Services/Models/Base/Consent.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using IYSIntegration.Application.Services.Models;
+using Newtonsoft.Json;
 
 namespace IYSIntegration.Application.Services.Models.Base
 {
@@ -56,7 +57,11 @@ namespace IYSIntegration.Application.Services.Models.Base
         public bool? IsSuccess { get; set; }
 
         [JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public string? BatchError { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("batchError")]
+        public ConsentBatchErrorModel? BatchErrorModel { get; set; }
 
         [JsonIgnore]
         public string? CompanyCode { get; set; }

--- a/IYSIntegration.Application/Services/Models/ConsentErrorReportModels.cs
+++ b/IYSIntegration.Application/Services/Models/ConsentErrorReportModels.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+
+namespace IYSIntegration.Application.Services.Models
+{
+    public sealed class ConsentBatchErrorModel
+    {
+        [JsonPropertyName("errors")]
+        public List<ConsentBatchErrorItem> Errors { get; set; } = new();
+    }
+
+    public sealed class ConsentBatchErrorItem
+    {
+        [JsonPropertyName("index")]
+        public int? Index { get; set; }
+
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+    }
+
+    public sealed class ConsentErrorCompanyStats
+    {
+        [JsonPropertyName("companyCode")]
+        public string? CompanyCode { get; set; }
+
+        [JsonPropertyName("consentCount")]
+        public int ConsentCount { get; set; }
+
+        [JsonPropertyName("errorCount")]
+        public int ErrorCount { get; set; }
+
+        [JsonPropertyName("codes")]
+        public List<ConsentErrorCodeStats> Codes { get; set; } = new();
+    }
+
+    public sealed class ConsentErrorCodeStats
+    {
+        [JsonPropertyName("code")]
+        public string Code { get; set; } = string.Empty;
+
+        [JsonPropertyName("count")]
+        public int Count { get; set; }
+
+        [JsonPropertyName("messages")]
+        public List<string> Messages { get; set; } = new();
+    }
+}


### PR DESCRIPTION
## Summary
- deserialize stored batch error payloads into a typed model that is returned with error details
- add aggregation logic to compute error statistics per company and per error code
- expose a new GetErrorReportStats endpoint that surfaces the aggregated results

## Testing
- dotnet build IYSIntegration.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccec05f09c8322a69b3384a4ea5561