### PR TITLE
Add reporting window details to consent error stats

### DIFF
--- a/IYSIntegration.Application/Services/Models/ConsentErrorReportModels.cs
+++ b/IYSIntegration.Application/Services/Models/ConsentErrorReportModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Serialization;
 
 namespace IYSIntegration.Application.Services.Models
@@ -45,5 +46,33 @@ namespace IYSIntegration.Application.Services.Models
 
         [JsonPropertyName("messages")]
         public List<string> Messages { get; set; } = new();
+    }
+
+    public sealed class ConsentErrorReportStatsResult
+    {
+        private const string DateTimeFormat = "yyyy-MM-dd HH:mm:ss";
+
+        [JsonPropertyName("rangeStart")]
+        public DateTime RangeStart { get; set; }
+
+        [JsonPropertyName("rangeEnd")]
+        public DateTime RangeEnd { get; set; }
+
+        [JsonPropertyName("rangeDescription")]
+        public string RangeDescription => $"{RangeStart.ToString(DateTimeFormat)} - {RangeEnd.ToString(DateTimeFormat)}";
+
+        [JsonPropertyName("dataRangeStart")]
+        public DateTime? DataRangeStart { get; set; }
+
+        [JsonPropertyName("dataRangeEnd")]
+        public DateTime? DataRangeEnd { get; set; }
+
+        [JsonPropertyName("dataRangeDescription")]
+        public string? DataRangeDescription => DataRangeStart.HasValue && DataRangeEnd.HasValue
+            ? $"{DataRangeStart.Value.ToString(DateTimeFormat)} - {DataRangeEnd.Value.ToString(DateTimeFormat)}"
+            : null;
+
+        [JsonPropertyName("companies")]
+        public List<ConsentErrorCompanyStats> Companies { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- add a response model that exposes the consent error stats together with reporting ranges
- extend the consent error stats service to populate the requested and actual data ranges

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf34fb8c08322a6057bd2add35dbf