### PR TITLE
Add TACIR consent lookup endpoint

### DIFF
--- a/IYSIntegration.API/Controllers/ScheduledController.cs
+++ b/IYSIntegration.API/Controllers/ScheduledController.cs
@@ -9,18 +9,21 @@ namespace IYSIntegration.API.Controllers
     {
         private readonly SendConsentToIysService _singleConsentAddService;
         private readonly PullConsentFromIysService _pullConsentService;
+        private readonly PullConsentLookupService _pullConsentLookupService;
         private readonly SendConsentToSalesforceService _sfConsentService;
         private readonly ErrorReportingService _sendConsentErrorService;
 
         public ScheduledController(
                                    SendConsentToIysService singleConsentAddService,
                                    PullConsentFromIysService pullConsentService,
+                                   PullConsentLookupService pullConsentLookupService,
                                    SendConsentToSalesforceService sfConsentService,
                                    ErrorReportingService sendConsentErrorService
                                    )
         {
             _singleConsentAddService = singleConsentAddService;
             _pullConsentService = pullConsentService;
+            _pullConsentLookupService = pullConsentLookupService;
             _sfConsentService = sfConsentService;
             _sendConsentErrorService = sendConsentErrorService;
         }
@@ -37,6 +40,13 @@ namespace IYSIntegration.API.Controllers
         public async Task<IActionResult> PullConsent([FromQuery] int batchSize, bool resetAfter = false)
         {
             var result = await _pullConsentService.RunAsync(batchSize, resetAfter);
+            return StatusCode(result.IsSuccessful() ? 200 : 500, result);
+        }
+
+        [HttpGet("getTacirPullConsents")]
+        public async Task<IActionResult> GetTacirPullConsents([FromQuery] int dayCount)
+        {
+            var result = await _pullConsentLookupService.GetRecentConsentsAsync(dayCount);
             return StatusCode(result.IsSuccessful() ? 200 : 500, result);
         }
 

--- a/IYSIntegration.API/Program.cs
+++ b/IYSIntegration.API/Program.cs
@@ -27,6 +27,7 @@ internal class Program
         builder.Services.AddScoped<ISyncConsentService, SyncConsentService>();
         builder.Services.AddScoped<SendConsentToIysService>();
         builder.Services.AddScoped<PullConsentFromIysService>();
+        builder.Services.AddScoped<PullConsentLookupService>();
         builder.Services.AddScoped<SendConsentToSalesforceService>();
         builder.Services.AddScoped<ErrorReportingService>();
 

--- a/IYSIntegration.Application/Services/Constants/QueryStrings.cs
+++ b/IYSIntegration.Application/Services/Constants/QueryStrings.cs
@@ -603,6 +603,19 @@
                 ORDER BY CreateDate ASC;
                 ";
 
+        public static string GetPullConsentsByFilter = @"
+            SELECT
+                                Id,
+                                Recipient,
+                                [Type],
+                                Status
+                        FROM dbo.IysPullConsent (nolock)
+                WHERE CompanyCode IN @CompanyCodes
+                  AND RecipientType = @RecipientType
+                  AND CreateDate >= @StartDate
+                ORDER BY CreateDate DESC;
+                ";
+
         public static string UpdatePullConsentStatuses = @"
             UPDATE dbo.IysPullConsent
             SET Status = @Status,

--- a/IYSIntegration.Application/Services/DbService.cs
+++ b/IYSIntegration.Application/Services/DbService.cs
@@ -90,6 +90,27 @@ namespace IYSIntegration.Application.Services
             }
         }
 
+        public async Task<List<PullConsentSummary>> GetPullConsentsAsync(DateTime startDate, string recipientType, IEnumerable<string> companyCodes)
+        {
+            using (var connection = new SqlConnection(_configuration.GetValue<string>("ConnectionStrings:SfdcMasterData")))
+            {
+                await connection.OpenAsync();
+
+                var result = (await connection.QueryAsync<PullConsentSummary>(
+                    QueryStrings.GetPullConsentsByFilter,
+                    new
+                    {
+                        StartDate = startDate,
+                        RecipientType = recipientType,
+                        CompanyCodes = companyCodes
+                    })).ToList();
+
+                await connection.CloseAsync();
+
+                return result;
+            }
+        }
+
         public async Task<int> InsertConsentRequest(AddConsentRequest request)
         {
             using (var connection = new SqlConnection(_configuration.GetValue<string>("ConnectionStrings:SfdcMasterData")))

--- a/IYSIntegration.Application/Services/Interface/IDbService.cs
+++ b/IYSIntegration.Application/Services/Interface/IDbService.cs
@@ -27,5 +27,6 @@ namespace IYSIntegration.Application.Services.Interface
         Task UpdateSfConsentResponse(SfConsentResult consentResult);
         Task<List<Consent>> GetIYSConsentRequestErrors(DateTime? date = null);
         Task<T> UpdateLogFromResponseBase<T>(ResponseBase<T> response, int id);
+        Task<List<PullConsentSummary>> GetPullConsentsAsync(DateTime startDate, string recipientType, IEnumerable<string> companyCodes);
     }
 }

--- a/IYSIntegration.Application/Services/Models/Response/Consent/PullConsentSummary.cs
+++ b/IYSIntegration.Application/Services/Models/Response/Consent/PullConsentSummary.cs
@@ -1,0 +1,10 @@
+namespace IYSIntegration.Application.Services.Models.Response.Consent
+{
+    public class PullConsentSummary
+    {
+        public long Id { get; set; }
+        public string? Recipient { get; set; }
+        public string? Type { get; set; }
+        public string? Status { get; set; }
+    }
+}

--- a/IYSIntegration.Application/Services/PullConsentLookupService.cs
+++ b/IYSIntegration.Application/Services/PullConsentLookupService.cs
@@ -1,0 +1,50 @@
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models.Base;
+using IYSIntegration.Application.Services.Models.Response.Consent;
+using Microsoft.Extensions.Logging;
+
+namespace IYSIntegration.Application.Services
+{
+    public class PullConsentLookupService
+    {
+        private static readonly string[] TargetCompanyCodes = new[] { "BAI", "BOD" };
+        private const string TargetRecipientType = "TACIR";
+
+        private readonly ILogger<PullConsentLookupService> _logger;
+        private readonly IDbService _dbService;
+
+        public PullConsentLookupService(ILogger<PullConsentLookupService> logger, IDbService dbService)
+        {
+            _logger = logger;
+            _dbService = dbService;
+        }
+
+        public async Task<ResponseBase<List<PullConsentSummary>>> GetRecentConsentsAsync(int dayCount)
+        {
+            var response = new ResponseBase<List<PullConsentSummary>>();
+
+            if (dayCount <= 0)
+            {
+                response.Error("dayCount", "Gün parametresi 0'dan büyük olmalıdır.");
+                return response;
+            }
+
+            try
+            {
+                _logger.LogInformation("PullConsentLookupService.GetRecentConsentsAsync running at: {time} for last {dayCount} day(s)", DateTimeOffset.Now, dayCount);
+
+                var startDate = DateTime.Now.AddDays(-dayCount);
+                var consents = await _dbService.GetPullConsentsAsync(startDate, TargetRecipientType, TargetCompanyCodes);
+
+                response.Success(consents ?? new List<PullConsentSummary>());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "PullConsentLookupService.GetRecentConsentsAsync error for last {dayCount} day(s)", dayCount);
+                response.Error("Exception", ex.Message);
+            }
+
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a database query and service to fetch TACIR pull consents for the requested number of days
- expose the lookup through ScheduledController and register the new service for DI

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd2505aebc8322a3dbc2a5088e6e7c