### PR TITLE
Add token controller to expose cached token info

### DIFF
--- a/IYSIntegration.Proxy.API/Controllers/TokenController.cs
+++ b/IYSIntegration.Proxy.API/Controllers/TokenController.cs
@@ -1,0 +1,34 @@
+using IYSIntegration.Application.Services;
+using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Models.Response.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IYSIntegration.Proxy.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]/{companyCode}")]
+public class TokenController : ControllerBase
+{
+    private readonly IIysHelper _iysHelper;
+    private readonly ICacheService _cacheService;
+
+    public TokenController(IIysHelper iysHelper, ICacheService cacheService)
+    {
+        _iysHelper = iysHelper ?? throw new ArgumentNullException(nameof(iysHelper));
+        _cacheService = cacheService ?? throw new ArgumentNullException(nameof(cacheService));
+    }
+
+    [HttpGet("getTokenInfo")]
+    public async Task<ActionResult<Token>> GetTokenInfo([FromRoute] string companyCode)
+    {
+        var consentParams = _iysHelper.GetIysCode(companyCode);
+        Token? token = await _cacheService.GetCachedHashDataAsync<Token>("IYS_Token", consentParams.IysCode.ToString());
+
+        if (token is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(token);
+    }
+}


### PR DESCRIPTION
## Summary
- add a token controller that retrieves token information from the Redis cache using the requested company code

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5ef3a6008322912c7eb100c7cbea