### PR TITLE
Refine token lifecycle logging

### DIFF
--- a/IYSIntegration.Application/Services/Constants/QueryStrings.cs
+++ b/IYSIntegration.Application/Services/Constants/QueryStrings.cs
@@ -2,9 +2,30 @@
 {
     public partial class QueryStrings
     {
+        public static string InsertTokenLog = @"
+            INSERT INTO SfdcMasterData.dbo.IYSTokenLog
+                (
+                    CompanyCode,
+                    AccessTokenMasked,
+                    RefreshTokenMasked,
+                    TokenCreateDateUtc,
+                    TokenRefreshDateUtc,
+                    Operation,
+                    CreatedAtUtc
+                )
+            VALUES(
+                @CompanyCode,
+                @AccessTokenMasked,
+                @RefreshTokenMasked,
+                @TokenCreateDateUtc,
+                @TokenRefreshDateUtc,
+                @Operation,
+                SYSUTCDATETIME()
+                );";
+
         public static string InsertRequest = @"
             INSERT INTO SfdcMasterData.dbo.IYSCallLog
-                (IysCode, 
+                (IysCode,
                  Action,
                  Url, 
                  Method,   

--- a/IYSIntegration.Application/Services/DbService.cs
+++ b/IYSIntegration.Application/Services/DbService.cs
@@ -2,6 +2,7 @@
 using IYSIntegration.Application.Services.Constants;
 using IYSIntegration.Application.Services.Interface;
 using IYSIntegration.Application.Services.Models.Base;
+using IYSIntegration.Application.Services.Models.Identity;
 using IYSIntegration.Application.Services.Models.Request;
 using IYSIntegration.Application.Services.Models.Response.Consent;
 using IYSIntegration.Application.Services.Models.Response.Schedule;
@@ -9,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using RestSharp;
+using System;
 using System.Data.SqlClient;
 namespace IYSIntegration.Application.Services
 {
@@ -50,6 +52,31 @@ namespace IYSIntegration.Application.Services
                 connection.Close();
 
                 return result;
+            }
+        }
+
+        public async Task InsertTokenLogAsync(TokenLogEntry tokenLogEntry)
+        {
+            if (tokenLogEntry is null)
+            {
+                throw new ArgumentNullException(nameof(tokenLogEntry));
+            }
+
+            using (var connection = new SqlConnection(_configuration.GetValue<string>("ConnectionStrings:SfdcMasterData")))
+            {
+                await connection.OpenAsync();
+
+                await connection.ExecuteAsync(QueryStrings.InsertTokenLog, new
+                {
+                    tokenLogEntry.CompanyCode,
+                    tokenLogEntry.AccessTokenMasked,
+                    tokenLogEntry.RefreshTokenMasked,
+                    tokenLogEntry.TokenCreateDateUtc,
+                    tokenLogEntry.TokenRefreshDateUtc,
+                    tokenLogEntry.Operation
+                });
+
+                await connection.CloseAsync();
             }
         }
 

--- a/IYSIntegration.Application/Services/Interface/IDbService.cs
+++ b/IYSIntegration.Application/Services/Interface/IDbService.cs
@@ -1,4 +1,5 @@
-﻿using IYSIntegration.Application.Services.Models.Base;
+using IYSIntegration.Application.Services.Models.Base;
+using IYSIntegration.Application.Services.Models.Identity;
 using IYSIntegration.Application.Services.Models.Request;
 using IYSIntegration.Application.Services.Models.Response.Consent;
 using IYSIntegration.Application.Services.Models.Response.Schedule;
@@ -28,5 +29,6 @@ namespace IYSIntegration.Application.Services.Interface
         Task<List<Consent>> GetIYSConsentRequestErrors(DateTime? date = null);
         Task<T> UpdateLogFromResponseBase<T>(ResponseBase<T> response, int id);
         Task<List<PullConsentSummary>> GetPullConsentsAsync(DateTime startDate, string recipientType, IEnumerable<string> companyCodes);
+        Task InsertTokenLogAsync(TokenLogEntry tokenLogEntry);
     }
 }

--- a/IYSIntegration.Application/Services/IysIdentityService.cs
+++ b/IYSIntegration.Application/Services/IysIdentityService.cs
@@ -1,10 +1,14 @@
-﻿using IYSIntegration.Application.Services.Interface;
+using IYSIntegration.Application.Services.Interface;
 using IYSIntegration.Application.Services.Models.Identity;
 using IYSIntegration.Application.Services.Models.Response.Identity;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using RestSharp;
+using System;
+using System.Globalization;
+using System.Threading;
 
 namespace IYSIntegration.Application.Services;
 
@@ -12,16 +16,26 @@ public class IysIdentityService : IIysIdentityService
 {
     private readonly ICacheService _cacheService;
     private readonly IConfiguration _config;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly int TokenExpiry;
     private readonly int RefreshTokenExpiry;
     private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
-    ILogger<IysIdentityService> _logger;
+    private readonly ILogger<IysIdentityService> _logger;
+    private const int TokenMaskSegmentLength = 4;
+    private const string TokenMaskSeparator = ".....";
+    private const string OperationNew = "NEW";
+    private const string OperationRefresh = "REFRESH";
 
-    public IysIdentityService(IConfiguration config, ILogger<IysIdentityService> logger, ICacheService cacheService)
+    public IysIdentityService(
+        IConfiguration config,
+        ILogger<IysIdentityService> logger,
+        ICacheService cacheService,
+        IServiceScopeFactory scopeFactory)
     {
         _config = config;
         _logger = logger;
         _cacheService = cacheService;
+        _scopeFactory = scopeFactory;
         TokenExpiry = _config.GetValue<int>($"TokenExpiry", 7000);
         RefreshTokenExpiry = _config.GetValue<int>($"RefreshTokenExpiry", 14000);
     }
@@ -72,6 +86,7 @@ public class IysIdentityService : IIysIdentityService
             var refreshToken = JsonConvert.DeserializeObject<Token>(response.Content);
             refreshToken.TokenValidTill = DateTime.UtcNow.AddSeconds(TokenExpiry);
             refreshToken.RefreshTokenValidTill = DateTime.UtcNow.AddSeconds(RefreshTokenExpiry);
+            refreshToken.CreateDate = token.CreateDate == default ? DateTime.UtcNow : token.CreateDate;
             refreshToken.RefreshDate = DateTime.UtcNow;
             refreshToken.PreviousDate = previousDate;
             return refreshToken;
@@ -96,14 +111,26 @@ public class IysIdentityService : IIysIdentityService
                 var previouseValidDate = token.RefreshTokenValidTill ?? DateTime.MinValue;
                 token = await GetNewToken(iysCode, previouseValidDate) ?? throw new Exception("Token alınamadı");
                 await _cacheService.SetCacheHashDataAsync("IYS_Token", iysCode.ToString(), token);
+                await LogTokenLifecycleAsync(iysCode, token, OperationNew);
 
             }
             else if (token.TokenValidTill < DateTime.UtcNow)
             {
                 var previouseValidDate = token.TokenValidTill ?? DateTime.MinValue;
-                token = await RefreshToken(token, previouseValidDate);
-                token ??= await GetNewToken(iysCode, previouseValidDate);
-                await _cacheService.SetCacheHashDataAsync("IYS_Token", iysCode.ToString(), token);
+                var refreshedToken = await RefreshToken(token, previouseValidDate);
+
+                if (refreshedToken is not null)
+                {
+                    token = refreshedToken;
+                    await _cacheService.SetCacheHashDataAsync("IYS_Token", iysCode.ToString(), token);
+                    await LogTokenLifecycleAsync(iysCode, token, OperationRefresh);
+                }
+                else
+                {
+                    token = await GetNewToken(iysCode, previouseValidDate) ?? throw new Exception("Token alınamadı");
+                    await _cacheService.SetCacheHashDataAsync("IYS_Token", iysCode.ToString(), token);
+                    await LogTokenLifecycleAsync(iysCode, token, OperationNew);
+                }
             }
 
             return token;
@@ -117,5 +144,113 @@ public class IysIdentityService : IIysIdentityService
         {
             _semaphore.Release();
         }
+    }
+
+    private async Task LogTokenLifecycleAsync(int iysCode, Token token, string operation)
+    {
+        if (token is null)
+        {
+            return;
+        }
+
+        string? companyCode = null;
+
+        try
+        {
+            companyCode = ResolveCompanyCode(iysCode);
+
+            if (string.IsNullOrWhiteSpace(companyCode))
+            {
+                companyCode = iysCode.ToString(CultureInfo.InvariantCulture);
+            }
+
+            var tokenCreateDate = token.CreateDate != default
+                ? token.CreateDate
+                : token.RefreshDate != default
+                    ? token.RefreshDate
+                    : DateTime.UtcNow;
+
+            var logEntry = new TokenLogEntry
+            {
+                CompanyCode = companyCode,
+                AccessTokenMasked = MaskToken(token.AccessToken),
+                RefreshTokenMasked = MaskToken(token.RefreshToken),
+                TokenCreateDateUtc = tokenCreateDate,
+                TokenRefreshDateUtc = token.RefreshDate != default ? token.RefreshDate : (DateTime?)null,
+                Operation = operation
+            };
+
+            using var scope = _scopeFactory.CreateScope();
+            var dbService = scope.ServiceProvider.GetRequiredService<IDbService>();
+            await dbService.InsertTokenLogAsync(logEntry);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Token loglaması sırasında hata oluştu (CompanyCode: {CompanyCode}, IysCode: {IysCode}, Operation: {Operation}).",
+                companyCode ?? string.Empty,
+                iysCode,
+                operation);
+        }
+    }
+
+    private string? ResolveCompanyCode(int iysCode)
+    {
+        foreach (var section in _config.GetChildren())
+        {
+            if (string.Equals(section.Key, "ConnectionStrings", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var iysValue = _config.GetValue<int?>($"{section.Key}:IysCode");
+            var brandValue = _config.GetValue<int?>($"{section.Key}:BrandCode");
+
+            if (iysValue == iysCode || brandValue == iysCode)
+            {
+                return NormalizeCompanyCode(section.Key);
+            }
+        }
+
+        return null;
+    }
+
+    private static string NormalizeCompanyCode(string companyCode)
+    {
+        if (string.IsNullOrWhiteSpace(companyCode))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = companyCode.Trim();
+
+        if (string.Equals(trimmed, "BAI", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(trimmed, "BOD", StringComparison.OrdinalIgnoreCase))
+        {
+            return "BOD";
+        }
+
+        return trimmed;
+    }
+
+    private static string? MaskToken(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return null;
+        }
+
+        var trimmed = token.Trim();
+
+        if (trimmed.Length <= TokenMaskSegmentLength * 2)
+        {
+            return trimmed;
+        }
+
+        var firstPart = trimmed.Substring(0, TokenMaskSegmentLength);
+        var lastPart = trimmed.Substring(trimmed.Length - TokenMaskSegmentLength, TokenMaskSegmentLength);
+
+        return string.Concat(firstPart, TokenMaskSeparator, lastPart);
     }
 }

--- a/IYSIntegration.Application/Services/Models/Identity/TokenLogEntry.cs
+++ b/IYSIntegration.Application/Services/Models/Identity/TokenLogEntry.cs
@@ -1,0 +1,17 @@
+namespace IYSIntegration.Application.Services.Models.Identity
+{
+    public sealed class TokenLogEntry
+    {
+        public string CompanyCode { get; set; } = string.Empty;
+
+        public string? AccessTokenMasked { get; set; }
+
+        public string? RefreshTokenMasked { get; set; }
+
+        public DateTime TokenCreateDateUtc { get; set; }
+
+        public DateTime? TokenRefreshDateUtc { get; set; }
+
+        public string Operation { get; set; } = string.Empty;
+    }
+}

--- a/IYSIntegration.Application/Services/Models/Response/Identity/Token.cs
+++ b/IYSIntegration.Application/Services/Models/Response/Identity/Token.cs
@@ -25,11 +25,38 @@ namespace IYSIntegration.Application.Services.Models.Response.Identity
         [JsonProperty("refreshTokenValidTill")]
         public DateTime? RefreshTokenValidTill { get; set; }
 
+        [JsonProperty("tokenValidTillLocal")]
+        public string? TokenValidTillLocal => FormatUtcPlus3Date(TokenValidTill);
+
+        [JsonProperty("refreshTokenValidTillLocal")]
+        public string? RefreshTokenValidTillLocal => FormatUtcPlus3Date(RefreshTokenValidTill);
+
         [JsonIgnore]
         public DateTime RefreshDate { get; set; }
 
         [JsonIgnore]
         public DateTime CreateDate { get; set; }
         public DateTime PreviousDate { get; internal set; }
+
+        private static string? FormatUtcPlus3Date(DateTime? dateTime)
+        {
+            if (!dateTime.HasValue)
+            {
+                return null;
+            }
+
+            var utcDateTime = dateTime.Value;
+
+            utcDateTime = utcDateTime.Kind switch
+            {
+                DateTimeKind.Unspecified => DateTime.SpecifyKind(utcDateTime, DateTimeKind.Utc),
+                DateTimeKind.Local => utcDateTime.ToUniversalTime(),
+                _ => utcDateTime
+            };
+
+            var utcPlusThree = utcDateTime.ToUniversalTime().AddHours(3);
+
+            return $"{utcPlusThree:yyyy-MM-dd HH:mm:ss} (UTC+3)";
+        }
     }
 }

--- a/Script/[dbo].[IYSTokenLog].sql
+++ b/Script/[dbo].[IYSTokenLog].sql
@@ -1,0 +1,21 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TABLE [dbo].[IYSTokenLog]
+(
+    [Id] INT IDENTITY(1,1) NOT NULL CONSTRAINT [PK_IYSTokenLog] PRIMARY KEY,
+    [CompanyCode] NVARCHAR(32) NOT NULL,
+    [AccessTokenMasked] NVARCHAR(256) NULL,
+    [RefreshTokenMasked] NVARCHAR(256) NULL,
+    [TokenCreateDateUtc] DATETIME2(0) NOT NULL,
+    [TokenRefreshDateUtc] DATETIME2(0) NULL,
+    [Operation] NVARCHAR(32) NOT NULL,
+    [CreatedAtUtc] DATETIME2(0) NOT NULL CONSTRAINT [DF_IYSTokenLog_CreatedAtUtc] DEFAULT (SYSUTCDATETIME())
+);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_IYSTokenLog_CompanyCode]
+    ON [dbo].[IYSTokenLog]([CompanyCode], [CreatedAtUtc]);
+GO


### PR DESCRIPTION
## Summary
- expose UTC+3 formatted strings for token and refresh token expiration fields returned by getTokenInfo
- ensure date conversion handles unspecified and local kinds before applying the UTC+3 offset
- capture token issuance and refresh operations by logging masked token values and acquisition timestamps via the identity service and database helper
- add a dedicated SQL script that creates the IYSTokenLog table without storing IYS codes or validity periods for auditing

## Testing
- `dotnet test` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6226ace883228210dbc878517e1c