### PR TITLE
Restore multiple query consent contract

### DIFF
--- a/IYSIntegration.API/Program.cs
+++ b/IYSIntegration.API/Program.cs
@@ -24,6 +24,7 @@ internal class Program
             var auth = config.GetValue<string>("BaseIysProxyAuth");
             return new IysProxy(url, auth);
         });
+        builder.Services.AddScoped<IIysProxy>(provider => provider.GetRequiredService<IysProxy>());
         builder.Services.AddScoped<SendConsentToIysService>();
         builder.Services.AddScoped<PullConsentFromIysService>();
         builder.Services.AddScoped<PullConsentLookupService>();

--- a/IYSIntegration.Application/Services/Interface/IDbService.cs
+++ b/IYSIntegration.Application/Services/Interface/IDbService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Identity;
 using IYSIntegration.Application.Services.Models.Request;
@@ -15,6 +16,11 @@ namespace IYSIntegration.Application.Services.Interface
         Task<bool> PullConsentExists(string companyCode, string recipient, string? type = null);
         Task<bool> SuccessfulConsentRequestExists(string companyCode, string recipient, string? type = null);
         Task<List<string>> GetExistingConsentRecipients(string companyCode, string? type, IEnumerable<string> recipients);
+        Task<Dictionary<string, ConsentStateInfo>> GetLatestConsentStatesAsync(
+            string companyCode,
+            string recipientType,
+            string? type,
+            IEnumerable<string> recipients);
         Task UpdateConsentResponseFromResponse(ResponseBase<AddConsentResult> response);
         Task<ConsentResultLog> GetConsentRequest(string id);
         Task<List<ConsentRequestLog>> GetPendingConsents(int rowCount);

--- a/IYSIntegration.Application/Services/Models/Base/ConsentStateInfo.cs
+++ b/IYSIntegration.Application/Services/Models/Base/ConsentStateInfo.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace IYSIntegration.Application.Services.Models.Base
+{
+    public class ConsentStateInfo
+    {
+        public string Recipient { get; set; } = string.Empty;
+
+        public string? Status { get; set; }
+
+        public DateTime? ConsentDate { get; set; }
+
+        public bool HasStoredHistory { get; set; }
+
+        public void ApplyStatus(string status, bool hasStoredHistory)
+        {
+            Status = status;
+            HasStoredHistory = hasStoredHistory;
+        }
+    }
+}

--- a/IYSIntegration.Application/Services/Models/Response/Consent/MultipleQueryConsentResult.cs
+++ b/IYSIntegration.Application/Services/Models/Response/Consent/MultipleQueryConsentResult.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace IYSIntegration.Application.Services.Models.Response.Consent
 {
     public class MultipleQueryConsentResult
     {
-
         [JsonProperty("requestId")]
         public string RequestId { get; set; }
 

--- a/IYSIntegration.Application/Services/SendConsentToIysService.cs
+++ b/IYSIntegration.Application/Services/SendConsentToIysService.cs
@@ -1,3 +1,4 @@
+using System;
 using IYSIntegration.Application.Services.Interface;
 using IYSIntegration.Application.Services.Models.Base;
 using IYSIntegration.Application.Services.Models.Request;
@@ -6,7 +7,12 @@ using IYSIntegration.Application.Services.Models.Response.Schedule;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
 
 namespace IYSIntegration.Application.Services;
 
@@ -14,7 +20,7 @@ public class SendConsentToIysService
 {
     private readonly ILogger<SendConsentToIysService> _logger;
     private readonly IDbService _dbService;
-    private readonly IysProxy _client;
+    private readonly IIysProxy _client;
     private readonly IIysHelper _iysHelper;
     private static readonly HashSet<string> OverdueErrorCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
@@ -27,7 +33,7 @@ public class SendConsentToIysService
         ILogger<SendConsentToIysService> logger,
         IDbService dbHelper,
         IIysHelper iysHelper,
-        IysProxy client,
+        IIysProxy client,
         IConfiguration configuration)
     {
         _logger = logger;
@@ -45,10 +51,9 @@ public class SendConsentToIysService
         int failedCount = 0;
         int successCount = 0;
 
-        _logger.LogInformation("SingleConsentAddService started at {Time}", DateTimeOffset.Now);
-
         try
         {
+            // Bekleyen izin kayıtlarını çekip şirket bazında gruplayacağız.
             var pendingConsents = await _dbService.GetPendingConsents(rowCount);
             var groupedConsents = new Dictionary<string, List<ConsentRequestLog>>(StringComparer.OrdinalIgnoreCase);
 
@@ -86,64 +91,166 @@ public class SendConsentToIysService
 
             foreach (var group in groupedConsents)
             {
-                foreach (var log in group.Value)
+                var companyCode = group.Key;
+
+                var groupedByRecipientAndType = group.Value
+                    .GroupBy(log => new ConsentGroupKey(
+                            log.RecipientType?.Trim() ?? string.Empty,
+                            log.Type?.Trim() ?? string.Empty),
+                        ConsentGroupKeyComparer.Instance);
+
+                foreach (var consentGroup in groupedByRecipientAndType)
                 {
-                    try
+                    // Aynı kanal ve iletişim türü için bekleyen kayıtları birlikte değerlendiriyoruz.
+                    var recipientType = consentGroup.Key.RecipientType;
+                    var consentType = consentGroup.Key.Type;
+
+                    var recipients = consentGroup
+                        .Select(log => log.Recipient)
+                        .Where(recipient => !string.IsNullOrWhiteSpace(recipient))
+                        .Select(recipient => recipient!.Trim())
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+
+                    // İlgili alıcıların veritabanındaki en güncel durum bilgilerini çekiyoruz.
+                    var latestStates = await _dbService.GetLatestConsentStatesAsync(
+                        companyCode,
+                        recipientType,
+                        string.IsNullOrWhiteSpace(consentType) ? null : consentType,
+                        recipients);
+
+                    latestStates ??= new Dictionary<string, ConsentStateInfo>(StringComparer.OrdinalIgnoreCase);
+
+                    if (NeedsApprovalRefresh(consentGroup, latestStates))
                     {
-                        var request = new AddConsentRequest
+                        // Gerekliyse IYS'deki ON kayıtlarını queryMultipleConsent ile tazeliyoruz.
+                        var queryInfo = await GetApprovedConsentEntriesAsync(
+                            companyCode,
+                            recipientType,
+                            string.IsNullOrWhiteSpace(consentType) ? null : consentType,
+                            recipients);
+
+                        if (queryInfo.Messages.Count > 0)
                         {
-                            IysCode = log.IysCode,
-                            BrandCode = log.BrandCode,
-                            CompanyCode = group.Key,
-                            Consent = new Consent
+                            response.AddMessage(queryInfo.Messages);
+                        }
+
+                        foreach (var entry in queryInfo.Entries)
+                        {
+                            var trimmedRecipient = entry?.Recipient?.Trim();
+                            if (string.IsNullOrWhiteSpace(trimmedRecipient))
                             {
-                                ConsentDate = log.ConsentDate,
-                                Recipient = log.Recipient,
-                                RecipientType = log.RecipientType,
-                                Source = log.Source,
-                                Status = log.Status,
-                                Type = log.Type
+                                continue;
                             }
-                        };
 
-                        var addResponse = await _client.PostJsonAsync<Consent, AddConsentResult>($"consents/{group.Key}/addConsent", request.Consent);
+                            if (!latestStates.TryGetValue(trimmedRecipient, out var state))
+                            {
+                                state = new ConsentStateInfo
+                                {
+                                    Recipient = trimmedRecipient,
+                                    HasStoredHistory = false
+                                };
+                                latestStates[trimmedRecipient] = state;
+                            }
 
-                        addResponse.Id = log.Id;
+                            var entryStatus = string.IsNullOrWhiteSpace(entry.Status)
+                                ? "ON"
+                                : entry.Status!.Trim();
 
-                        var update = CreateConsentResponseUpdate(addResponse);
-                        if (update != null)
-                        {
-                            responseUpdates.Add(update);
+                            state.ApplyStatus(entryStatus, true);
+
+                            if (!string.IsNullOrWhiteSpace(entry.Reason))
+                            {
+                                response.AddMessage(
+                                    $"query.reason.{companyCode}.{trimmedRecipient}",
+                                    entry.Reason!.Trim());
+                            }
                         }
+                    }
 
-                        if (addResponse.IsSuccessful() && addResponse.HttpStatusCode >= 200 && addResponse.HttpStatusCode < 300)
+                    foreach (var log in consentGroup)
+                    {
+                        // Gönderimden önce iş kurallarını uyguluyoruz.
+                        if (ShouldSkipConsent(log, latestStates, out var skipReason))
                         {
-                            Interlocked.Increment(ref successCount);
-                        }
-                        else
-                        {
+                            responseUpdates.Add(CreateOverdueUpdate(log, skipReason));
                             results.Add(new LogResult
                             {
                                 Id = log.Id,
-                                CompanyCode = group.Key,
+                                CompanyCode = companyCode,
+                                Status = "Skipped",
                                 Messages = new Dictionary<string, string>
                                 {
-                                    { "Add Error", BuildErrorMessage(addResponse) }
+                                    { "SkipReason", skipReason }
                                 }
                             });
-                            Interlocked.Increment(ref failedCount);
+                            continue;
                         }
 
-                    }
-                    catch (Exception ex)
-                    {
-                        results.Add(new LogResult { Id = log.Id, CompanyCode = group.Key, Messages = new Dictionary<string, string> { { "Exception", ex.Message } } });
-                        Interlocked.Increment(ref failedCount);
-                        _logger.LogError(ex, "Exception in SingleConsentAddService for log ID {Id}", log.Id);
-                        response.Error();
+                        try
+                        {
+                            // IYS servis çağrısında kullanılacak isteği hazırlıyoruz.
+                            var request = new AddConsentRequest
+                            {
+                                IysCode = log.IysCode,
+                                BrandCode = log.BrandCode,
+                                CompanyCode = companyCode,
+                                Consent = new Consent
+                                {
+                                    ConsentDate = log.ConsentDate,
+                                    Recipient = log.Recipient,
+                                    RecipientType = log.RecipientType,
+                                    Source = log.Source,
+                                    Status = log.Status,
+                                    Type = log.Type
+                                }
+                            };
+
+                            var addResponse = await _client.PostJsonAsync<Consent, AddConsentResult>("consents/{companyCode}/addConsent", request.Consent);
+
+                            addResponse.Id = log.Id;
+
+                            var update = CreateConsentResponseUpdate(addResponse, out var addMessage);
+                            if (update != null)
+                            {
+                                responseUpdates.Add(update);
+                            }
+
+                            if (addMessage.HasValue)
+                            {
+                                response.AddMessage(addMessage.Value.Key, addMessage.Value.Value);
+                            }
+
+                            if (addResponse.IsSuccessful() && addResponse.HttpStatusCode >= 200 && addResponse.HttpStatusCode < 300)
+                            {
+                                Interlocked.Increment(ref successCount);
+                            }
+                            else
+                            {
+                                results.Add(new LogResult
+                                {
+                                    Id = log.Id,
+                                    CompanyCode = companyCode,
+                                    Messages = new Dictionary<string, string>
+                                    {
+                                        { "Add Error", BuildErrorMessage(addResponse) }
+                                    }
+                                });
+                                Interlocked.Increment(ref failedCount);
+                            }
+
+                        }
+                        catch (Exception ex)
+                        {
+                            results.Add(new LogResult { Id = log.Id, CompanyCode = companyCode, Messages = new Dictionary<string, string> { { "Exception", ex.Message } } });
+                            Interlocked.Increment(ref failedCount);
+                            _logger.LogError(ex, "Exception in SingleConsentAddService for log ID {Id}", log.Id);
+                            response.Error();
+                        }
                     }
                 }
             }
+
 
         }
         catch (Exception ex)
@@ -152,6 +259,21 @@ public class SendConsentToIysService
             results.Add(new LogResult { Id = 0, CompanyCode = "", Status = "Failed", Messages = new Dictionary<string, string> { { "Exception", ex.Message } } });
             response.Error("SINGLE_CONSENT_ADD_FATAL", "Service failed with an unexpected exception.");
         }
+
+        var updatesToPersist = responseUpdates.ToList();
+        if (updatesToPersist.Count > 0)
+        {
+            try
+            {
+                await _dbService.UpdateConsentResponses(updatesToPersist);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to persist consent response updates.");
+                response.AddMessage("PersistError", ex.Message);
+            }
+        }
+
         foreach (var result in results)
         {
             response.AddMessage(result.GetMessages());
@@ -161,11 +283,25 @@ public class SendConsentToIysService
             SuccessCount = successCount,
             FailedCount = failedCount
         };
+
+        // Tüm toplu mesajları tek seferde logluyoruz.
+        if (response.Messages is { Count: > 0 })
+        {
+            foreach (var message in response.Messages)
+            {
+                _logger.LogInformation("SingleConsentWorker mesaj {Key}: {Value}", message.Key, message.Value);
+            }
+        }
+
         return response;
     }
 
-    private ConsentResponseUpdate? CreateConsentResponseUpdate(ResponseBase<AddConsentResult> response)
+    private ConsentResponseUpdate? CreateConsentResponseUpdate(
+        ResponseBase<AddConsentResult> response,
+        out KeyValuePair<string, string>? responseMessage)
     {
+        responseMessage = null;
+
         if (response == null)
         {
             return null;
@@ -183,15 +319,21 @@ public class SendConsentToIysService
 
         if (response.HttpStatusCode == 200)
         {
-            _logger.LogInformation("SingleConsentWorker ID {Id} ve {Status} statu olarak alındı", response.Id, response.HttpStatusCode);
+            responseMessage = new KeyValuePair<string, string>(
+                $"add.success.{response.Id}",
+                $"Log {response.Id} için IYS gönderimi başarıyla tamamlandı (HTTP {response.HttpStatusCode}).");
         }
         else if (isConsentOverdue)
         {
-            _logger.LogWarning("SingleConsentWorker ID {Id} ve IYS geciken/mükerrer {Errors} olarak alındı", response.Id, errors);
+            responseMessage = new KeyValuePair<string, string>(
+                $"add.overdue.{response.Id}",
+                $"Log {response.Id} için IYS yanıtı gecikmeli veya mükerrer: {errors}.");
         }
         else
         {
-            _logger.LogError("SingleConsentWorker ID {Id} ve {Status} statu kodu ve {Errors} IYS hataları ile alınamadı", response.Id, response.HttpStatusCode, errors);
+            responseMessage = new KeyValuePair<string, string>(
+                $"add.error.{response.Id}",
+                $"Log {response.Id} için IYS gönderimi başarısız: {BuildErrorMessage(response)}");
         }
 
         var serializedError = response.OriginalError == null
@@ -211,6 +353,301 @@ public class SendConsentToIysService
             BatchError = serializedError,
             IsOverdue = isConsentOverdue
         };
+    }
+
+    // Gönderim öncesi iş kurallarını tek noktada değerlendiriyoruz.
+    private bool ShouldSkipConsent(ConsentRequestLog log, IDictionary<string, ConsentStateInfo> states, out string reason)
+    {
+        reason = string.Empty;
+
+        if (log == null)
+        {
+            return false;
+        }
+
+        var recipient = log.Recipient?.Trim();
+        var status = log.Status?.Trim();
+
+        if (string.IsNullOrWhiteSpace(recipient) || string.IsNullOrWhiteSpace(status))
+        {
+            return false;
+        }
+
+        states ??= new Dictionary<string, ConsentStateInfo>(StringComparer.OrdinalIgnoreCase);
+        states.TryGetValue(recipient, out var existingState);
+
+        if (existingState != null && !string.IsNullOrWhiteSpace(existingState.Status)
+            && string.Equals(existingState.Status, status, StringComparison.OrdinalIgnoreCase))
+        {
+            reason = $"SKIP_SAME_STATUS: Stored status {existingState.Status} matches pending status.";
+            return true;
+        }
+
+        if (string.Equals(status, "RET", StringComparison.OrdinalIgnoreCase)
+            && (existingState == null || !existingState.HasStoredHistory))
+        {
+            reason = "SKIP_INITIAL_RET: No stored consent history exists for RET status.";
+            return true;
+        }
+
+        var logDate = ParseConsentDate(log.ConsentDate);
+        var storedDate = existingState?.ConsentDate;
+
+        if (storedDate.HasValue && logDate.HasValue && storedDate.Value >= logDate.Value)
+        {
+            reason = $"SKIP_STALE_DATE: Stored consent date {storedDate:O} is newer than pending consent date {logDate:O}.";
+            return true;
+        }
+
+        if (logDate.HasValue && logDate.Value < DateTime.UtcNow.AddDays(-3))
+        {
+            reason = $"SKIP_OUTDATED_CONSENT: Pending consent date {logDate:O} is older than 3 days.";
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool NeedsApprovalRefresh(IEnumerable<ConsentRequestLog> consentGroup, IDictionary<string, ConsentStateInfo> states)
+    {
+        if (consentGroup == null)
+        {
+            return false;
+        }
+
+        foreach (var log in consentGroup)
+        {
+            var status = log.Status?.Trim();
+            if (!string.Equals(status, "ON", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var recipient = log.Recipient?.Trim();
+            if (string.IsNullOrWhiteSpace(recipient))
+            {
+                continue;
+            }
+
+            if (states == null || !states.TryGetValue(recipient, out var existingState)
+                || !string.Equals(existingState.Status, "ON", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static DateTime? ParseConsentDate(string? consentDate)
+    {
+        if (string.IsNullOrWhiteSpace(consentDate))
+        {
+            return null;
+        }
+
+        var trimmed = consentDate.Trim();
+        var formats = new[]
+        {
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd HH:mm:ss.fff",
+            "yyyy-MM-ddTHH:mm:ss",
+            "yyyy-MM-ddTHH:mm:ss.fff",
+            "dd.MM.yyyy HH:mm:ss"
+        };
+
+        if (DateTime.TryParseExact(trimmed, formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+        {
+            return parsed;
+        }
+
+        if (DateTime.TryParse(trimmed, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out parsed))
+        {
+            return parsed;
+        }
+
+        if (DateTime.TryParse(trimmed, CultureInfo.CurrentCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out parsed))
+        {
+            return parsed;
+        }
+
+        return null;
+    }
+
+    // IYS queryMultipleConsent çağrısını yapıp dönüşleri tek yerde topluyoruz.
+    private async Task<QueryMultipleConsentInfo> GetApprovedConsentEntriesAsync(
+        string companyCode,
+        string recipientType,
+        string? consentType,
+        IReadOnlyCollection<string> recipients)
+    {
+        var info = new QueryMultipleConsentInfo();
+
+        if (string.IsNullOrWhiteSpace(companyCode)
+            || string.IsNullOrWhiteSpace(recipientType)
+            || recipients == null
+            || recipients.Count == 0)
+        {
+            return info;
+        }
+
+        var recipientList = recipients
+            .Where(recipient => !string.IsNullOrWhiteSpace(recipient))
+            .Select(recipient => recipient.Trim())
+            .Where(recipient => !string.IsNullOrWhiteSpace(recipient))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (recipientList.Count == 0)
+        {
+            return info;
+        }
+
+        var request = new RecipientKeyWithList
+        {
+            RecipientType = recipientType,
+            Type = string.IsNullOrWhiteSpace(consentType) ? null : consentType,
+            Recipients = recipientList
+        };
+
+        try
+        {
+            var response = await _client.PostJsonAsync<RecipientKeyWithList, QueryMultipleConsentEnvelope>(
+                $"consents/{companyCode}/queryMultipleConsent",
+                request);
+
+            if (response?.Data?.List is JArray array)
+            {
+                foreach (var token in array)
+                {
+                    switch (token.Type)
+                    {
+                        case JTokenType.String:
+                            var recipient = token.Value<string>()?.Trim();
+                            if (!string.IsNullOrWhiteSpace(recipient))
+                            {
+                                info.Entries.Add(new MultipleQueryConsentEntry
+                                {
+                                    Recipient = recipient!,
+                                    Status = "ON"
+                                });
+                            }
+                            break;
+                        case JTokenType.Object:
+                            var entry = token.ToObject<MultipleQueryConsentEntry>();
+                            if (entry != null && !string.IsNullOrWhiteSpace(entry.Recipient))
+                            {
+                                entry.Recipient = entry.Recipient.Trim();
+                                if (string.IsNullOrWhiteSpace(entry.Status))
+                                {
+                                    entry.Status = "ON";
+                                }
+
+                                info.Entries.Add(entry);
+                            }
+                            break;
+                    }
+                }
+            }
+
+            if (response != null)
+            {
+                if (response.Messages is { Count: > 0 })
+                {
+                    foreach (var kv in response.Messages)
+                    {
+                        if (!info.Messages.ContainsKey(kv.Key))
+                        {
+                            info.Messages[kv.Key] = kv.Value;
+                        }
+                    }
+                }
+
+                if (!response.IsSuccessful())
+                {
+                    info.Messages[$"query.error.{companyCode}"] = BuildErrorMessage(response);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            info.Messages[$"query.exception.{companyCode}"] = ex.Message;
+        }
+
+        return info;
+    }
+
+    private static ConsentResponseUpdate CreateOverdueUpdate(ConsentRequestLog log, string message)
+    {
+        return new ConsentResponseUpdate
+        {
+            Id = log.Id,
+            LogId = log.LogId ?? 0,
+            IsSuccess = false,
+            TransactionId = null,
+            CreationDate = null,
+            BatchError = message,
+            IsOverdue = true
+        };
+    }
+
+    // queryMultipleConsent yanıtındaki kayıtları ve mesajları tek noktada tutuyoruz.
+    private sealed class QueryMultipleConsentInfo
+    {
+        public List<MultipleQueryConsentEntry> Entries { get; } = new();
+
+        public Dictionary<string, string> Messages { get; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private sealed class QueryMultipleConsentEnvelope
+    {
+        [JsonProperty("requestId")]
+        public string? RequestId { get; set; }
+
+        [JsonProperty("list")]
+        public JToken? List { get; set; }
+    }
+
+    private sealed class MultipleQueryConsentEntry
+    {
+        [JsonProperty("recipient")]
+        public string Recipient { get; set; } = string.Empty;
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("reason")]
+        public string? Reason { get; set; }
+    }
+
+    private sealed record ConsentGroupKey(string RecipientType, string Type);
+
+    private sealed class ConsentGroupKeyComparer : IEqualityComparer<ConsentGroupKey>
+    {
+        public static ConsentGroupKeyComparer Instance { get; } = new ConsentGroupKeyComparer();
+
+        public bool Equals(ConsentGroupKey? x, ConsentGroupKey? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            return string.Equals(x.RecipientType, y.RecipientType, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(x.Type, y.Type, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(ConsentGroupKey obj)
+        {
+            var recipientType = obj.RecipientType?.ToUpperInvariant() ?? string.Empty;
+            var type = obj.Type?.ToUpperInvariant() ?? string.Empty;
+            return HashCode.Combine(recipientType, type);
+        }
     }
 
     private static string BuildErrorMessage<T>(ResponseBase<T> response)


### PR DESCRIPTION
## Summary
- restore the original `MultipleQueryConsentResult` contract so external callers continue receiving the simple list payload
- move the detailed parsing of `queryMultipleConsent` results into `SendConsentToIysService`, capturing reasons locally without altering shared models

## Testing
- `dotnet test IYSIntegration.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcef4669c83229930a83baa181a3e