### PR TITLE
Add proxy endpoint to query multiple consent request status

### DIFF
--- a/IYS.Application/Services/Models/Response/Consent/MultipleConsentRequestStatusResult.cs
+++ b/IYS.Application/Services/Models/Response/Consent/MultipleConsentRequestStatusResult.cs
@@ -1,0 +1,37 @@
+using Newtonsoft.Json;
+
+namespace IYS.Application.Services.Models.Response.Consent
+{
+    public class MultipleConsentRequestStatusResult
+    {
+        [JsonProperty("requestId")]
+        public string RequestId { get; set; }
+
+        [JsonProperty("subRequests")]
+        public MultipleConsentRequestStatusSubRequest[] SubRequests { get; set; }
+    }
+
+    public class MultipleConsentRequestStatusSubRequest
+    {
+        [JsonProperty("requestId", NullValueHandling = NullValueHandling.Ignore)]
+        public string RequestId { get; set; }
+
+        [JsonProperty("subRequestId", NullValueHandling = NullValueHandling.Ignore)]
+        public string SubRequestId { get; set; }
+
+        [JsonProperty("index", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Index { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; }
+
+        [JsonProperty("transactionId", NullValueHandling = NullValueHandling.Ignore)]
+        public string TransactionId { get; set; }
+
+        [JsonProperty("creationDate", NullValueHandling = NullValueHandling.Ignore)]
+        public string CreationDate { get; set; }
+
+        [JsonProperty("error", NullValueHandling = NullValueHandling.Ignore)]
+        public Error Error { get; set; }
+    }
+}

--- a/IYS.Proxy.API/Controllers/ConsentsController.cs
+++ b/IYS.Proxy.API/Controllers/ConsentsController.cs
@@ -165,4 +165,31 @@ public class ConsentsController : ControllerBase
 
         return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
     }
+
+    /// <summary>
+    /// Çoklu izin ekleme isteği sorgulama
+    /// "{_baseUrl}/sps/{IysCode}/brands/{BrandCode}/consents/request/{requestId}"
+    /// </summary>
+    /// <param name="companyCode"></param>
+    /// <param name="requestId"></param>
+    /// <returns></returns>
+    [HttpGet("queryMultipleConsentRequest/{requestId}")]
+    public async Task<ActionResult<ResponseBase<MultipleConsentRequestStatusResult>>> QueryMultipleConsentRequest(
+        [FromRoute] string companyCode,
+        [FromRoute] string requestId)
+    {
+        var consentParams = _iysHelper.GetIysCode(companyCode);
+
+        var iysRequest = new IysRequest<DummyRequest>
+        {
+            IysCode = consentParams.IysCode,
+            Url = $"{_baseUrl}/sps/{consentParams.IysCode}/brands/{consentParams.BrandCode}/consents/request/{requestId}",
+            Action = "Query Multiple Consent Request",
+            Method = RestSharp.Method.Get
+        };
+
+        var result = await _clientHelper.Execute<MultipleConsentRequestStatusResult, DummyRequest>(iysRequest);
+
+        return StatusCode(result.HttpStatusCode == 0 ? 500 : result.HttpStatusCode, result);
+    }
 }


### PR DESCRIPTION
## Summary
- add response models for multiple consent request status payloads
- expose a GET endpoint on the proxy to query asynchronous multiple consent requests by request id

## Testing
- dotnet build IYSIntegration.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe710d08083229fad791362c409ef