### PR TITLE
Add in-memory synchronization for token halt timestamps

### DIFF
--- a/IYS.Application/Services/Interface/ICacheService.cs
+++ b/IYS.Application/Services/Interface/ICacheService.cs
@@ -1,4 +1,4 @@
-﻿namespace IYS.Application.Services.Interface
+namespace IYS.Application.Services.Interface
 {
     public interface ICacheService
     {
@@ -6,5 +6,7 @@
         public Task SetCacheDataAsync<T>(string cacheKey, T data);
         public Task<T> GetCachedHashDataAsync<T>(string hashKey, string Key);
         public Task SetCacheHashDataAsync<T>(string hashKey, string Key, T data);
+        public Task<DateTime?> GetCachedHaltUntilAsync(string cacheKey);
+        public Task SetCachedHaltUntilAsync(string cacheKey, DateTime? haltUntilUtc);
     }
 }


### PR DESCRIPTION
## Summary
- extend the cache abstraction to support caching the halt-until timestamp alongside token data
- update the hybrid cache and identity services to consult the in-memory halt data first and keep it synchronized with the database

## Testing
- dotnet build IYSIntegration.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da77d46c7483228f01a780998d2dfd